### PR TITLE
Add device code login for SSH/headless setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ pi -e ./pi-grok-cli
 /login
 ```
 
-Select **"Grok CLI"** from the provider list. This opens the xAI OAuth page in your browser.
+Select **"Grok CLI"** from the provider list, then choose a login method:
+
+- **Browser OAuth callback** opens the xAI OAuth page and waits for the local callback.
+- **Device code (SSH/headless)** shows a verification URL and short code. Open the URL on any browser, enter/confirm the code, and pi waits until xAI returns tokens to the remote machine.
 
 ### Select a model
 

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -404,20 +404,27 @@ async function exchangeCode(
 async function sleep(ms: number, signal?: AbortSignal) {
   if (signal?.aborted) throw new Error('Login cancelled');
   await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(timeout);
-        reject(new Error('Login cancelled'));
-      },
-      { once: true },
-    );
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(new Error('Login cancelled'));
+    };
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }
 
-function readNumber(value: unknown, fallback: number): number {
-  return typeof value === 'number' ? value : Number(value ?? fallback);
+function readPositiveNumber(value: unknown, fallback: number, field: string): number {
+  const parsed = typeof value === 'number' ? value : Number(value ?? fallback);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new XaiOAuthError(
+      `xAI device authorization returned invalid ${field}.`,
+      XaiErrorCode.DEVICE_AUTHORIZATION_INVALID,
+    );
+  }
+  return parsed;
 }
 
 async function requestDeviceCode(deviceAuthorizationEndpoint: string) {
@@ -456,8 +463,8 @@ async function requestDeviceCode(deviceAuthorizationEndpoint: string) {
     deviceCode,
     userCode,
     verificationUri: validateEndpoint(verificationUri, 'verification_uri'),
-    intervalSeconds: readNumber(payload.interval, 5),
-    expiresInSeconds: readNumber(payload.expires_in, 1800),
+    intervalSeconds: readPositiveNumber(payload.interval, 5, 'interval'),
+    expiresInSeconds: readPositiveNumber(payload.expires_in, 1800, 'expires_in'),
   };
 }
 
@@ -471,8 +478,18 @@ async function loginWithDeviceCode(
       XaiErrorCode.DEVICE_AUTHORIZATION_UNAVAILABLE,
     );
   }
+  const onDeviceCode =
+    typeof (callbacks as { onDeviceCode?: unknown }).onDeviceCode === 'function'
+      ? callbacks.onDeviceCode
+      : undefined;
+  if (!onDeviceCode) {
+    throw new XaiOAuthError(
+      'xAI device authorization requires a device-code capable pi login UI.',
+      XaiErrorCode.DEVICE_AUTHORIZATION_UNAVAILABLE,
+    );
+  }
   const device = await requestDeviceCode(discovery.device_authorization_endpoint);
-  callbacks.onDeviceCode({
+  onDeviceCode({
     userCode: device.userCode,
     verificationUri: device.verificationUri,
     intervalSeconds: device.intervalSeconds,
@@ -544,16 +561,19 @@ export async function login(
   callbacks: import('@earendil-works/pi-ai').OAuthLoginCallbacks,
 ): Promise<import('@earendil-works/pi-ai').OAuthCredentials> {
   const discovery = await discover();
-  const method =
-    discovery.device_authorization_endpoint && typeof callbacks.onSelect === 'function'
-      ? await callbacks.onSelect({
-          message: 'Select Grok CLI login method:',
-          options: [
-            { id: 'browser', label: 'Browser OAuth callback' },
-            { id: 'device', label: 'Device code (SSH/headless)' },
-          ],
-        })
-      : 'browser';
+  const supportsDeviceLogin =
+    discovery.device_authorization_endpoint &&
+    typeof callbacks.onSelect === 'function' &&
+    typeof (callbacks as { onDeviceCode?: unknown }).onDeviceCode === 'function';
+  const method = supportsDeviceLogin
+    ? await callbacks.onSelect({
+        message: 'Select Grok CLI login method:',
+        options: [
+          { id: 'browser', label: 'Browser OAuth callback' },
+          { id: 'device', label: 'Device code (SSH/headless)' },
+        ],
+      })
+    : 'browser';
   if (!method) throw new Error('Login cancelled');
   if (method === 'device') return loginWithDeviceCode(discovery, callbacks);
 

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -36,6 +36,7 @@ const TOKEN_REQUEST_TIMEOUT_MS = Number.parseInt(
 interface XaiDiscovery {
   authorization_endpoint: string;
   token_endpoint: string;
+  device_authorization_endpoint?: string;
 }
 
 export interface XaiOAuthCredentials {
@@ -146,9 +147,18 @@ async function discover(): Promise<XaiDiscovery> {
     'authorization_endpoint',
   );
   const tokenEndpoint = validateEndpoint(String(payload.token_endpoint ?? ''), 'token_endpoint');
+  const deviceAuthorizationEndpoint = payload.device_authorization_endpoint
+    ? validateEndpoint(
+        String(payload.device_authorization_endpoint),
+        'device_authorization_endpoint',
+      )
+    : undefined;
   return {
     authorization_endpoint: authorizationEndpoint,
     token_endpoint: tokenEndpoint,
+    ...(deviceAuthorizationEndpoint
+      ? { device_authorization_endpoint: deviceAuthorizationEndpoint }
+      : {}),
   };
 }
 
@@ -318,6 +328,45 @@ async function tokenResponseJson(
   }
 }
 
+async function tokenResponsePayload(response: Response): Promise<Record<string, unknown>> {
+  const text = await tokenResponseText(response);
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return { error: `HTTP ${response.status}`, error_description: text };
+  }
+}
+
+function credentialsFromLoginPayload(
+  payload: Record<string, unknown>,
+  tokenEndpoint: string,
+  invalidCode: string,
+  label: string,
+): XaiOAuthCredentials {
+  const access = String(payload.access_token ?? '');
+  const refresh = String(payload.refresh_token ?? '');
+  if (!access) {
+    throw new XaiOAuthError(`xAI ${label} did not return access_token.`, invalidCode);
+  }
+  if (!refresh) {
+    throw new XaiOAuthError(`xAI ${label} did not return refresh_token.`, invalidCode);
+  }
+  const expiresIn =
+    typeof payload.expires_in === 'number'
+      ? payload.expires_in
+      : Number(payload.expires_in ?? 3600);
+  return {
+    access,
+    refresh,
+    expires: Date.now() + expiresIn * 1000 - REFRESH_SKEW_MS,
+    tokenEndpoint,
+    discovery: { authorization_endpoint: '', token_endpoint: tokenEndpoint },
+    idToken: String(payload.id_token ?? ''),
+    tokenType: String(payload.token_type ?? 'Bearer'),
+    baseUrl: getBaseUrl(),
+  };
+}
+
 async function exchangeCode(
   tokenEndpoint: string,
   code: string,
@@ -342,39 +391,151 @@ async function exchangeCode(
       XaiErrorCode.TOKEN_EXCHANGE_FAILED,
     );
   }
-  const payload = await tokenResponseJson(
-    response,
-    XaiErrorCode.TOKEN_EXCHANGE_FAILED,
+  return credentialsFromLoginPayload(
+    await tokenResponseJson(response, XaiErrorCode.TOKEN_EXCHANGE_FAILED, 'token exchange'),
+    tokenEndpoint,
+    XaiErrorCode.TOKEN_EXCHANGE_INVALID,
     'token exchange',
   );
-  const access = String(payload.access_token ?? '');
-  const refresh = String(payload.refresh_token ?? '');
-  if (!access) {
+}
+
+// ─── Device authorization ───────────────────────────────────────────────────
+
+async function sleep(ms: number, signal?: AbortSignal) {
+  if (signal?.aborted) throw new Error('Login cancelled');
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timeout);
+        reject(new Error('Login cancelled'));
+      },
+      { once: true },
+    );
+  });
+}
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' ? value : Number(value ?? fallback);
+}
+
+async function requestDeviceCode(deviceAuthorizationEndpoint: string) {
+  const response = await fetchTokenResponse(
+    deviceAuthorizationEndpoint,
+    new URLSearchParams({
+      client_id: CLIENT_ID,
+      scope: SCOPE,
+    }),
+    XaiErrorCode.DEVICE_AUTHORIZATION_FAILED,
+    'device authorization',
+  );
+  if (!response.ok) {
     throw new XaiOAuthError(
-      'xAI token exchange did not return access_token.',
-      XaiErrorCode.TOKEN_EXCHANGE_INVALID,
+      `xAI device authorization failed: ${response.status} ${await tokenResponseText(response)}`,
+      XaiErrorCode.DEVICE_AUTHORIZATION_FAILED,
     );
   }
-  if (!refresh) {
+  const payload = await tokenResponseJson(
+    response,
+    XaiErrorCode.DEVICE_AUTHORIZATION_FAILED,
+    'device authorization',
+  );
+  const deviceCode = String(payload.device_code ?? '');
+  const userCode = String(payload.user_code ?? '');
+  const verificationUri = String(
+    payload.verification_uri_complete ?? payload.verification_uri ?? '',
+  );
+  if (!deviceCode || !userCode || !verificationUri) {
     throw new XaiOAuthError(
-      'xAI token exchange did not return refresh_token.',
-      XaiErrorCode.TOKEN_EXCHANGE_INVALID,
+      'xAI device authorization did not return device_code, user_code, and verification_uri.',
+      XaiErrorCode.DEVICE_AUTHORIZATION_INVALID,
     );
   }
-  const expiresIn =
-    typeof payload.expires_in === 'number'
-      ? payload.expires_in
-      : Number(payload.expires_in ?? 3600);
   return {
-    access,
-    refresh,
-    expires: Date.now() + expiresIn * 1000 - REFRESH_SKEW_MS,
-    tokenEndpoint,
-    discovery: { authorization_endpoint: '', token_endpoint: tokenEndpoint },
-    idToken: String(payload.id_token ?? ''),
-    tokenType: String(payload.token_type ?? 'Bearer'),
-    baseUrl: getBaseUrl(),
+    deviceCode,
+    userCode,
+    verificationUri: validateEndpoint(verificationUri, 'verification_uri'),
+    intervalSeconds: readNumber(payload.interval, 5),
+    expiresInSeconds: readNumber(payload.expires_in, 1800),
   };
+}
+
+async function loginWithDeviceCode(
+  discovery: XaiDiscovery,
+  callbacks: import('@earendil-works/pi-ai').OAuthLoginCallbacks,
+): Promise<XaiOAuthCredentials> {
+  if (!discovery.device_authorization_endpoint) {
+    throw new XaiOAuthError(
+      'xAI OIDC discovery did not include a device authorization endpoint.',
+      XaiErrorCode.DEVICE_AUTHORIZATION_UNAVAILABLE,
+    );
+  }
+  const device = await requestDeviceCode(discovery.device_authorization_endpoint);
+  callbacks.onDeviceCode({
+    userCode: device.userCode,
+    verificationUri: device.verificationUri,
+    intervalSeconds: device.intervalSeconds,
+    expiresInSeconds: device.expiresInSeconds,
+  });
+  callbacks.onProgress?.('Waiting for xAI device authorization...');
+
+  const deadline = Date.now() + device.expiresInSeconds * 1000;
+  const poll = async (intervalSeconds: number): Promise<XaiOAuthCredentials> => {
+    if (Date.now() >= deadline) {
+      throw new XaiOAuthError(
+        'Timed out waiting for xAI device authorization.',
+        XaiErrorCode.DEVICE_AUTHORIZATION_FAILED,
+      );
+    }
+    await sleep(intervalSeconds * 1000, callbacks.signal);
+    const response = await fetchTokenResponse(
+      discovery.token_endpoint,
+      new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        client_id: CLIENT_ID,
+        device_code: device.deviceCode,
+      }),
+      XaiErrorCode.DEVICE_AUTHORIZATION_FAILED,
+      'device token exchange',
+    );
+    if (response.ok) {
+      const credentials = credentialsFromLoginPayload(
+        await tokenResponseJson(
+          response,
+          XaiErrorCode.DEVICE_AUTHORIZATION_FAILED,
+          'device token exchange',
+        ),
+        discovery.token_endpoint,
+        XaiErrorCode.DEVICE_AUTHORIZATION_INVALID,
+        'device token exchange',
+      );
+      credentials.discovery = discovery;
+      return credentials;
+    }
+
+    const payload = await tokenResponsePayload(response);
+    if (payload.error === 'authorization_pending') return poll(intervalSeconds);
+    if (payload.error === 'slow_down') return poll(intervalSeconds + 5);
+    throw new XaiOAuthError(
+      `xAI device authorization failed: ${response.status} ${String(
+        payload.error_description ?? payload.error ?? 'unknown error',
+      )}`,
+      XaiErrorCode.DEVICE_AUTHORIZATION_FAILED,
+      payload.error === 'access_denied' || payload.error === 'expired_token',
+    );
+  };
+
+  return poll(Math.max(1, device.intervalSeconds));
+}
+
+async function loginWithBrowserCallback() {
+  const { verifier, challenge } = await generatePKCE();
+  const state = base64Url(crypto.getRandomValues(new Uint8Array(16)));
+  const nonce = base64Url(crypto.getRandomValues(new Uint8Array(16)));
+  const callback = await startCallbackServer();
+
+  return { callback, challenge, nonce, state, verifier };
 }
 
 // ─── Login (called by pi's /login flow) ──────────────────────────────────────
@@ -383,30 +544,39 @@ export async function login(
   callbacks: import('@earendil-works/pi-ai').OAuthLoginCallbacks,
 ): Promise<import('@earendil-works/pi-ai').OAuthCredentials> {
   const discovery = await discover();
-  const { verifier, challenge } = await generatePKCE();
-  const state = base64Url(crypto.getRandomValues(new Uint8Array(16)));
-  const nonce = base64Url(crypto.getRandomValues(new Uint8Array(16)));
-  const callback = await startCallbackServer();
+  const method =
+    discovery.device_authorization_endpoint && typeof callbacks.onSelect === 'function'
+      ? await callbacks.onSelect({
+          message: 'Select Grok CLI login method:',
+          options: [
+            { id: 'browser', label: 'Browser OAuth callback' },
+            { id: 'device', label: 'Device code (SSH/headless)' },
+          ],
+        })
+      : 'browser';
+  if (!method) throw new Error('Login cancelled');
+  if (method === 'device') return loginWithDeviceCode(discovery, callbacks);
 
+  const browser = await loginWithBrowserCallback();
   try {
     const authUrl = new URL(discovery.authorization_endpoint);
     authUrl.searchParams.set('response_type', 'code');
     authUrl.searchParams.set('client_id', CLIENT_ID);
-    authUrl.searchParams.set('redirect_uri', callback.redirectUri);
+    authUrl.searchParams.set('redirect_uri', browser.callback.redirectUri);
     authUrl.searchParams.set('scope', SCOPE);
-    authUrl.searchParams.set('code_challenge', challenge);
+    authUrl.searchParams.set('code_challenge', browser.challenge);
     authUrl.searchParams.set('code_challenge_method', 'S256');
-    authUrl.searchParams.set('state', state);
-    authUrl.searchParams.set('nonce', nonce);
+    authUrl.searchParams.set('state', browser.state);
+    authUrl.searchParams.set('nonce', browser.nonce);
     authUrl.searchParams.set('plan', 'generic');
     authUrl.searchParams.set('referrer', 'pi-grok-cli');
 
     callbacks.onAuth({
       url: authUrl.toString(),
-      instructions: `Authorize xAI, then return to pi. Callback listener: ${callback.redirectUri}`,
+      instructions: `Authorize xAI, then return to pi. Callback listener: ${browser.callback.redirectUri}`,
     });
 
-    const result = await callback.waitForCallback(180_000);
+    const result = await browser.callback.waitForCallback(180_000);
 
     if (result.error) {
       const code =
@@ -416,7 +586,7 @@ export async function login(
           : XaiErrorCode.AUTHORIZATION_FAILED;
       throw new XaiOAuthError(result.errorDescription ?? result.error, code);
     }
-    if (result.state !== state) {
+    if (result.state !== browser.state) {
       throw new XaiOAuthError(
         'xAI OAuth state mismatch — possible CSRF.',
         XaiErrorCode.STATE_MISMATCH,
@@ -432,13 +602,13 @@ export async function login(
     const credentials = await exchangeCode(
       discovery.token_endpoint,
       result.code,
-      callback.redirectUri,
-      verifier,
+      browser.callback.redirectUri,
+      browser.verifier,
     );
     credentials.discovery = discovery;
     return credentials;
   } finally {
-    callback.server.close();
+    browser.callback.server.close();
   }
 }
 

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -31,6 +31,12 @@ export const XaiErrorCode = {
   TOKEN_EXCHANGE_FAILED: 'token_exchange_failed',
   /** Token exchange returned an invalid payload. */
   TOKEN_EXCHANGE_INVALID: 'token_exchange_invalid',
+  /** Device authorization is not supported by discovery. */
+  DEVICE_AUTHORIZATION_UNAVAILABLE: 'device_authorization_unavailable',
+  /** Device authorization failed (network, denied, expired). */
+  DEVICE_AUTHORIZATION_FAILED: 'device_authorization_failed',
+  /** Device authorization returned an invalid payload. */
+  DEVICE_AUTHORIZATION_INVALID: 'device_authorization_invalid',
   /** Refresh token is missing or empty. */
   REFRESH_MISSING: 'refresh_missing',
   /** Token refresh failed (expired, revoked). */

--- a/tests/auth/oauth.test.ts
+++ b/tests/auth/oauth.test.ts
@@ -313,6 +313,85 @@ describe('OAuth helpers without network access', () => {
     );
   });
 
+  it('logs in with device authorization for SSH/headless sessions', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    const onSelect = vi.fn(async () => 'device');
+    const onDeviceCode = vi.fn();
+    const onProgress = vi.fn();
+    let tokenPolls = 0;
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      if (input === 'https://auth.x.ai/.well-known/openid-configuration') {
+        return Response.json({
+          ...discoveryDocument,
+          device_authorization_endpoint: 'https://auth.x.ai/oauth/device/code',
+        });
+      }
+      if (input === 'https://auth.x.ai/oauth/device/code') {
+        return Response.json({
+          device_code: 'device-code',
+          user_code: 'ABCD-EFGH',
+          verification_uri: 'https://accounts.x.ai/oauth/device',
+          verification_uri_complete: 'https://accounts.x.ai/oauth/device?user_code=ABCD-EFGH',
+          expires_in: 1800,
+          interval: 5,
+        });
+      }
+      tokenPolls += 1;
+      if (tokenPolls === 1) {
+        return Response.json({ error: 'authorization_pending' }, { status: 400 });
+      }
+      return Response.json({
+        access_token: 'device-access',
+        refresh_token: 'device-refresh',
+        expires_in: 900,
+        id_token: 'device-id',
+        token_type: 'Bearer',
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    const resultPromise = login({
+      onSelect,
+      onDeviceCode,
+      onProgress,
+    } as unknown as OAuthLoginCallbacks);
+
+    await vi.waitFor(() => expect(onDeviceCode).toHaveBeenCalledOnce());
+    expect(onSelect).toHaveBeenCalledWith({
+      message: 'Select Grok CLI login method:',
+      options: [
+        { id: 'browser', label: 'Browser OAuth callback' },
+        { id: 'device', label: 'Device code (SSH/headless)' },
+      ],
+    });
+    expect(onDeviceCode).toHaveBeenCalledWith({
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://accounts.x.ai/oauth/device?user_code=ABCD-EFGH',
+      intervalSeconds: 5,
+      expiresInSeconds: 1800,
+    });
+    expect(onProgress).toHaveBeenCalledWith('Waiting for xAI device authorization...');
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      access: 'device-access',
+      refresh: 'device-refresh',
+      expires: expect.any(Number),
+      tokenEndpoint: 'https://auth.x.ai/oauth/token',
+      discovery: {
+        ...discoveryDocument,
+        device_authorization_endpoint: 'https://auth.x.ai/oauth/device/code',
+      },
+      idToken: 'device-id',
+      tokenType: 'Bearer',
+    });
+    expect((fetchMock.mock.calls[3]?.[1]?.body as URLSearchParams).toString()).toBe(
+      'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&client_id=b1a00492-073a-47ea-816f-4c329264a828&device_code=device-code',
+    );
+  });
+
   it('reports callback timeouts with a dedicated error code', async () => {
     vi.useFakeTimers();
     globalThis.fetch = vi.fn<typeof fetch>(async () => Response.json(discoveryDocument));

--- a/tests/auth/oauth.test.ts
+++ b/tests/auth/oauth.test.ts
@@ -21,6 +21,22 @@ const discoveryDocument = {
   authorization_endpoint: 'https://auth.x.ai/oauth/authorize',
   token_endpoint: 'https://auth.x.ai/oauth/token',
 };
+const deviceDiscoveryDocument = {
+  ...discoveryDocument,
+  device_authorization_endpoint: 'https://auth.x.ai/oauth/device/code',
+};
+
+function deviceAuthorizationResponse(overrides: Record<string, unknown> = {}) {
+  return Response.json({
+    device_code: 'device-code',
+    user_code: 'ABCD-EFGH',
+    verification_uri: 'https://accounts.x.ai/oauth/device',
+    verification_uri_complete: 'https://accounts.x.ai/oauth/device?user_code=ABCD-EFGH',
+    expires_in: 1800,
+    interval: 5,
+    ...overrides,
+  });
+}
 
 function authorizeCallback(auth: { url: string }) {
   const url = new URL(auth.url);
@@ -322,20 +338,11 @@ describe('OAuth helpers without network access', () => {
     let tokenPolls = 0;
     const fetchMock = vi.fn<typeof fetch>(async (input) => {
       if (input === 'https://auth.x.ai/.well-known/openid-configuration') {
-        return Response.json({
-          ...discoveryDocument,
-          device_authorization_endpoint: 'https://auth.x.ai/oauth/device/code',
-        });
+        return Response.json(deviceDiscoveryDocument);
       }
-      if (input === 'https://auth.x.ai/oauth/device/code') {
-        return Response.json({
-          device_code: 'device-code',
-          user_code: 'ABCD-EFGH',
-          verification_uri: 'https://accounts.x.ai/oauth/device',
-          verification_uri_complete: 'https://accounts.x.ai/oauth/device?user_code=ABCD-EFGH',
-          expires_in: 1800,
-          interval: 5,
-        });
+      if (input === 'https://auth.x.ai/oauth/device/code') return deviceAuthorizationResponse();
+      if (input !== 'https://auth.x.ai/oauth/token') {
+        throw new Error(`Unexpected fetch URL: ${String(input)}`);
       }
       tokenPolls += 1;
       if (tokenPolls === 1) {
@@ -380,16 +387,71 @@ describe('OAuth helpers without network access', () => {
       refresh: 'device-refresh',
       expires: expect.any(Number),
       tokenEndpoint: 'https://auth.x.ai/oauth/token',
-      discovery: {
-        ...discoveryDocument,
-        device_authorization_endpoint: 'https://auth.x.ai/oauth/device/code',
-      },
+      discovery: deviceDiscoveryDocument,
       idToken: 'device-id',
       tokenType: 'Bearer',
     });
+    expect(fetchMock.mock.calls[2]?.[0]).toBe('https://auth.x.ai/oauth/token');
+    expect(fetchMock.mock.calls[3]?.[0]).toBe('https://auth.x.ai/oauth/token');
     expect((fetchMock.mock.calls[3]?.[1]?.body as URLSearchParams).toString()).toBe(
       'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&client_id=b1a00492-073a-47ea-816f-4c329264a828&device_code=device-code',
     );
+  });
+
+  it('rejects malformed device polling numbers before polling', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      if (input === 'https://auth.x.ai/.well-known/openid-configuration') {
+        return Response.json(deviceDiscoveryDocument);
+      }
+      if (input === 'https://auth.x.ai/oauth/device/code') {
+        return deviceAuthorizationResponse({ interval: '5s' });
+      }
+      throw new Error(`Unexpected fetch URL: ${String(input)}`);
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      login({
+        onSelect: async () => 'device',
+        onDeviceCode: vi.fn(),
+      } as unknown as OAuthLoginCallbacks),
+    ).rejects.toMatchObject({
+      code: XaiErrorCode.DEVICE_AUTHORIZATION_INVALID,
+      message: 'xAI device authorization returned invalid interval.',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to browser login when the UI has no device-code callback', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    const onSelect = vi.fn(async () => 'device');
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      if (input === 'https://auth.x.ai/.well-known/openid-configuration') {
+        return Response.json(deviceDiscoveryDocument);
+      }
+      return Response.json({
+        access_token: 'login-access',
+        refresh_token: 'login-refresh',
+        expires_in: 900,
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      login({
+        onAuth: authorizeCallback,
+        onSelect,
+      } as unknown as OAuthLoginCallbacks),
+    ).resolves.toMatchObject({
+      access: 'login-access',
+      refresh: 'login-refresh',
+    });
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      'https://auth.x.ai/.well-known/openid-configuration',
+      'https://auth.x.ai/oauth/token',
+    ]);
   });
 
   it('reports callback timeouts with a dedicated error code', async () => {


### PR DESCRIPTION
## Summary

Adds an xAI OAuth device authorization login option for Grok CLI. This makes `/login` easier on SSH/headless machines where the loopback browser callback is inconvenient or requires port forwarding.

The Grok CLI login flow now lets users choose between:

- Browser OAuth callback
- Device code (SSH/headless)

The device flow uses xAI discovery's `device_authorization_endpoint`, displays the verification URL/user code through pi's OAuth device-code callback, polls the token endpoint with the device grant, and stores the same OAuth credentials as the browser callback flow.

## Testing

- `bun run check`

## Note

This PR was generated with pi using GPT-5.5, based on testing the device-code workaround on a remote SSH machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a step-by-step login flow with two options: browser-based OAuth and device code login for SSH/headless use.
  * Users can now complete authentication remotely using a verification URL and code.

* **Bug Fixes**
  * Improved login handling for OAuth responses and polling, including clearer handling of authorization delays, access denial, and expired codes.
  * Better support for login failures when device authorization is unavailable or returns an invalid response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->