### PR TITLE
feat: show billing reset times in the user's timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Tokens auto-refresh 120s before expiry. To skip OAuth entirely, set `GROK_CLI_OA
 /grok-cli-usage
 ```
 
-Prints credits used / limit, remaining credits, and the reset time for the current billing period.
+Prints credits used / limit, remaining credits, and the reset time in your local system timezone (for example, `Jul 11, 13:01 GMT+7 Asia/Bangkok`) for the current billing period.
 
 ### 4. Image input on text-only models
 

--- a/src/provider/billing.ts
+++ b/src/provider/billing.ts
@@ -25,7 +25,7 @@ const RESET_FORMATTER = new Intl.DateTimeFormat(undefined, {
   timeZoneName: 'short',
 });
 
-const LOCAL_TIME_ZONE = RESET_FORMATTER.resolvedOptions().timeZone;
+export const LOCAL_TIME_ZONE = RESET_FORMATTER.resolvedOptions().timeZone;
 
 const billingHeaders = (token: string) => ({
   authorization: `Bearer ${token}`,

--- a/src/provider/billing.ts
+++ b/src/provider/billing.ts
@@ -16,14 +16,16 @@ interface BillingUsage {
   weekly?: WeeklyUsage;
 }
 
-const RESET_FORMATTER = new Intl.DateTimeFormat('en-US', {
+const RESET_FORMATTER = new Intl.DateTimeFormat(undefined, {
   month: 'short',
   day: 'numeric',
   hour: '2-digit',
   minute: '2-digit',
   hour12: false,
-  timeZone: 'America/Los_Angeles',
+  timeZoneName: 'short',
 });
+
+const LOCAL_TIME_ZONE = RESET_FORMATTER.resolvedOptions().timeZone;
 
 const billingHeaders = (token: string) => ({
   authorization: `Bearer ${token}`,
@@ -93,7 +95,7 @@ function formatReset(iso: string): string {
   const parts = RESET_FORMATTER.formatToParts(new Date(iso));
   const part = (type: string) => parts.find((p) => p.type === type)?.value ?? '';
   const hour = part('hour') === '24' ? '00' : part('hour');
-  return `${part('month')} ${part('day')}, ${hour}:${part('minute')} PT`;
+  return `${part('month')} ${part('day')}, ${hour}:${part('minute')} ${part('timeZoneName')} ${LOCAL_TIME_ZONE}`;
 }
 
 const detail = (label: string, value: string) => `      ${label.padEnd(9)}  ${value}`;

--- a/tests/provider/register.test.ts
+++ b/tests/provider/register.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import type { Api, Model, OAuthCredentials } from '@earendil-works/pi-ai';
 import type { ExtensionAPI, ProviderConfig } from '@earendil-works/pi-coding-agent';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LOCAL_TIME_ZONE } from '../../src/provider/billing.js';
 import { GROK_SHIM_TOOL_NAMES, grokToolsToActivate } from '../../src/tools/register.js';
 import * as webSearchDelegate from '../../src/tools/webSearchDelegate.js';
 
@@ -210,6 +211,11 @@ const billingFetchMock = (monthly: Response, credits: Response) =>
     return url.includes('format=credits') ? credits : monthly;
   });
 
+function expectReset(status: string) {
+  expect(status).toMatch(/Reset\s+.+\s(?:GMT[+-]\d+(?::\d+)?|UTC|[A-Z]{2,5})\s\S+/);
+  expect(status).toContain(LOCAL_TIME_ZONE);
+}
+
 async function runStatus(extension: Awaited<ReturnType<typeof setupExtension>>) {
   const notify = vi.fn();
   await extension.commands.get('grok-cli-usage')?.handler([], statusContext(notify));
@@ -243,11 +249,7 @@ describe('Grok CLI status command', () => {
     expect(status).toContain('1,421 / 4,000 used  36%');
     expect(status).toContain('2,579 credits');
     expect(status).toContain('1% used');
-    const localFormatter = new Intl.DateTimeFormat(undefined, { timeZoneName: 'short' });
-    expect(status).toContain(
-      localFormatter.formatToParts(new Date()).find((part) => part.type === 'timeZoneName')?.value,
-    );
-    expect(status).toContain(localFormatter.resolvedOptions().timeZone);
+    expectReset(status);
   });
 
   it('omits the weekly block when the credits endpoint is unavailable', async () => {
@@ -267,6 +269,7 @@ describe('Grok CLI status command', () => {
     const status = String(notify.mock.calls.at(-1)?.[0]);
     expect(status).toContain('172 / 4,000 used  4%');
     expect(status).toContain('3,828 credits');
+    expectReset(status);
   });
 
   it('uses the registered provider token when no env token is set', async () => {

--- a/tests/provider/register.test.ts
+++ b/tests/provider/register.test.ts
@@ -239,19 +239,15 @@ describe('Grok CLI status command', () => {
       accept: 'application/json',
     });
     expect(fetchMock.mock.calls[0]?.[1]?.headers).not.toHaveProperty('x-userid');
-    expect(notify.mock.calls.at(-1)?.[0]).toBe(
-      [
-        '  Usage:',
-        '    Monthly',
-        '      Credits    1,421 / 4,000 used  36%',
-        '      Remaining  2,579 credits',
-        '      Reset      Jun 30, 17:00 PT',
-        '',
-        '    Weekly',
-        '      Limit      1% used',
-        '      Reset      Jul 13, 17:19 PT',
-      ].join('\n'),
+    const status = String(notify.mock.calls.at(-1)?.[0]);
+    expect(status).toContain('1,421 / 4,000 used  36%');
+    expect(status).toContain('2,579 credits');
+    expect(status).toContain('1% used');
+    const localFormatter = new Intl.DateTimeFormat(undefined, { timeZoneName: 'short' });
+    expect(status).toContain(
+      localFormatter.formatToParts(new Date()).find((part) => part.type === 'timeZoneName')?.value,
     );
+    expect(status).toContain(localFormatter.resolvedOptions().timeZone);
   });
 
   it('omits the weekly block when the credits endpoint is unavailable', async () => {
@@ -268,15 +264,9 @@ describe('Grok CLI status command', () => {
     expect(fetchMock.mock.calls[1]?.[0]).toBe(
       'https://cli-chat-proxy.grok.com/v1/billing?format=credits',
     );
-    expect(notify.mock.calls.at(-1)?.[0]).toBe(
-      [
-        '  Usage:',
-        '    Monthly',
-        '      Credits    172 / 4,000 used  4%',
-        '      Remaining  3,828 credits',
-        '      Reset      Jul 31, 17:00 PT',
-      ].join('\n'),
-    );
+    const status = String(notify.mock.calls.at(-1)?.[0]);
+    expect(status).toContain('172 / 4,000 used  4%');
+    expect(status).toContain('3,828 credits');
   });
 
   it('uses the registered provider token when no env token is set', async () => {


### PR DESCRIPTION
## Summary

Display Grok CLI billing reset times in the local system timezone, including both the short offset/abbreviation and IANA timezone identifier (for example, `Jul 11, 13:01 GMT+7 Asia/Bangkok`). This makes it easier for users to see exactly when their quota resets without converting from Pacific Time.

## Testing

- `bun run check`

---

Generated with [pi](https://github.com/earendil-works/pi-coding-agent) using GPT-5.6, as noted in #3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Billing reset times now display in the user’s local timezone instead of a fixed Pacific Time zone.
  * Quota status messages include the local timezone name for clearer reset-time information.

* **Documentation**
  * Clarified that quota reset times use the local system timezone.
  * Added an example of the reset-time format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->