### PR TITLE
feat: configurable collapsed previews for Grok tool shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,18 @@ Vision configuration is read from `~/.pi/grok-cli-vision.json`. The file is crea
 
 `model` must identify an image-capable model. Invalid values are reported and replaced with safe defaults. Manual changes apply on the next image read.
 
+### Tool display modes
+
+pi's `Ctrl+O` keybinding still controls full tool expansion. pi-grok-cli adds a separate collapsed-view setting so Grok/Composer tool calls can use either summary-only or bounded-preview output.
+
+| Command | Description |
+| --- | --- |
+| `/grok-cli-tools:status` | Show the current collapsed-view display mode and preview limits. |
+| `/grok-cli-tools:minimal` | Show compact summaries only. |
+| `/grok-cli-tools:preview` | Default. Show key summaries plus bounded previews for search, listing, shell, and web results. |
+
+Configuration lives at `~/.pi/grok-cli-tools.json`.
+
 ### Common environment variables
 
 | Variable | Default | Description |

--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ pi's `Ctrl+O` keybinding still controls full tool expansion. pi-grok-cli adds a 
 | --- | --- |
 | `/grok-cli-tools:status` | Show the current collapsed-view display mode and preview limits. |
 | `/grok-cli-tools:minimal` | Show compact summaries only. |
-| `/grok-cli-tools:preview` | Default. Show key summaries plus bounded previews for search, listing, shell, and web results. |
+| `/grok-cli-tools:preview` | Default. Show key summaries plus bounded previews for search, listing, shell, Write calls, and web results. |
 
-Configuration lives at `~/.pi/grok-cli-tools.json`.
+Configuration lives at `~/.pi/grok-cli-tools.json`; `writeCallPreviewLines` controls collapsed Write call previews.
 
 ### Common environment variables
 

--- a/src/provider/register.ts
+++ b/src/provider/register.ts
@@ -11,6 +11,7 @@ import { getBaseUrl, type XaiOAuthCredentials } from '../auth/oauth.js';
 import { registerImagineFeature } from '../imagine/register.js';
 import { type GrokCliModelConfig, resolveModels } from '../models/catalog.js';
 import { sanitizePayload } from '../payload/sanitize.js';
+import { registerToolDisplayCommands } from '../tools/displayConfig.js';
 import { registerGrokTools } from '../tools/register.js';
 import {
   bindLivePiWebAccess,
@@ -85,6 +86,7 @@ export default function registerGrokCli(pi: ExtensionAPI) {
 
   registerGrokTools(pi);
   registerImagineFeature(pi);
+  registerToolDisplayCommands(pi);
 
   pi.on('session_start', async (_event, ctx) => {
     if (process.env.GROK_CLI_OAUTH_TOKEN) {

--- a/src/tools/displayConfig.ts
+++ b/src/tools/displayConfig.ts
@@ -14,7 +14,7 @@ export interface ToolDisplayConfig {
   lsPreviewEntries: number;
   shellTailLines: number;
   readPreviewLines: number;
-  writePreviewLines: number;
+  writeCallPreviewLines: number;
   webSearchPreviewChars: number;
 }
 
@@ -26,7 +26,7 @@ const MODE_DEFAULTS: Record<ToolDisplayMode, ToolDisplayConfig> = {
     lsPreviewEntries: 0,
     shellTailLines: 0,
     readPreviewLines: 0,
-    writePreviewLines: 0,
+    writeCallPreviewLines: 0,
     webSearchPreviewChars: 0,
   },
   preview: {
@@ -36,7 +36,7 @@ const MODE_DEFAULTS: Record<ToolDisplayMode, ToolDisplayConfig> = {
     lsPreviewEntries: 20,
     shellTailLines: 20,
     readPreviewLines: 0,
-    writePreviewLines: 0,
+    writeCallPreviewLines: 10,
     webSearchPreviewChars: 500,
   },
 };
@@ -97,7 +97,7 @@ export function normalizeToolDisplayConfig(
   normalizePositiveInteger(record, 'lsPreviewEntries', config, warnings);
   normalizePositiveInteger(record, 'shellTailLines', config, warnings);
   normalizePositiveInteger(record, 'readPreviewLines', config, warnings);
-  normalizePositiveInteger(record, 'writePreviewLines', config, warnings);
+  normalizePositiveInteger(record, 'writeCallPreviewLines', config, warnings);
   normalizePositiveInteger(record, 'webSearchPreviewChars', config, warnings);
 
   return config;
@@ -145,7 +145,7 @@ function formatConfig(config: ToolDisplayConfig, warning?: string): string {
     `lsPreviewEntries: ${config.lsPreviewEntries}`,
     `shellTailLines: ${config.shellTailLines}`,
     `readPreviewLines: ${config.readPreviewLines}`,
-    `writePreviewLines: ${config.writePreviewLines}`,
+    `writeCallPreviewLines: ${config.writeCallPreviewLines}`,
     `webSearchPreviewChars: ${config.webSearchPreviewChars}`,
     `config: ${getToolDisplayConfigPath()}`,
     warning ? `warning: ${warning}` : undefined,

--- a/src/tools/displayConfig.ts
+++ b/src/tools/displayConfig.ts
@@ -1,0 +1,179 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+
+export const TOOL_DISPLAY_MODES = ['minimal', 'preview'] as const;
+
+export type ToolDisplayMode = (typeof TOOL_DISPLAY_MODES)[number];
+
+export interface ToolDisplayConfig {
+  toolDisplay: ToolDisplayMode;
+  grepPreviewMatches: number;
+  globPreviewFiles: number;
+  lsPreviewEntries: number;
+  shellTailLines: number;
+  readPreviewLines: number;
+  writePreviewLines: number;
+  webSearchPreviewChars: number;
+}
+
+const MODE_DEFAULTS: Record<ToolDisplayMode, ToolDisplayConfig> = {
+  minimal: {
+    toolDisplay: 'minimal',
+    grepPreviewMatches: 0,
+    globPreviewFiles: 0,
+    lsPreviewEntries: 0,
+    shellTailLines: 0,
+    readPreviewLines: 0,
+    writePreviewLines: 0,
+    webSearchPreviewChars: 0,
+  },
+  preview: {
+    toolDisplay: 'preview',
+    grepPreviewMatches: 10,
+    globPreviewFiles: 20,
+    lsPreviewEntries: 20,
+    shellTailLines: 20,
+    readPreviewLines: 0,
+    writePreviewLines: 0,
+    webSearchPreviewChars: 500,
+  },
+};
+
+export const DEFAULT_TOOL_DISPLAY_CONFIG: ToolDisplayConfig = { ...MODE_DEFAULTS.preview };
+
+const homePath = () => process.env.HOME || homedir();
+
+export const getToolDisplayConfigPath = () =>
+  process.env.PI_GROK_CLI_TOOLS_CONFIG || join(homePath(), '.pi', 'grok-cli-tools.json');
+
+export interface LoadedToolDisplayConfig {
+  config: ToolDisplayConfig;
+  warning?: string;
+}
+
+function isDisplayMode(value: unknown): value is ToolDisplayMode {
+  return typeof value === 'string' && TOOL_DISPLAY_MODES.includes(value as ToolDisplayMode);
+}
+
+function normalizePositiveInteger(
+  raw: Record<string, unknown>,
+  key: keyof Omit<ToolDisplayConfig, 'toolDisplay'>,
+  config: ToolDisplayConfig,
+  warnings: string[],
+) {
+  if (!(key in raw)) return;
+  const value = raw[key];
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+    config[key] = value;
+    return;
+  }
+  warnings.push(`${key} must be a non-negative integer. Using ${config[key]}.`);
+}
+
+export function configForToolDisplayMode(mode: ToolDisplayMode): ToolDisplayConfig {
+  return { ...MODE_DEFAULTS[mode] };
+}
+
+export function normalizeToolDisplayConfig(
+  raw: Partial<ToolDisplayConfig>,
+  warnings: string[] = [],
+): ToolDisplayConfig {
+  const mode = isDisplayMode(raw.toolDisplay)
+    ? raw.toolDisplay
+    : DEFAULT_TOOL_DISPLAY_CONFIG.toolDisplay;
+  const config = configForToolDisplayMode(mode);
+
+  if ('toolDisplay' in raw && !isDisplayMode(raw.toolDisplay)) {
+    warnings.push(
+      `toolDisplay must be one of ${TOOL_DISPLAY_MODES.join(', ')}. Using ${config.toolDisplay}.`,
+    );
+  }
+
+  const record = raw as Record<string, unknown>;
+  normalizePositiveInteger(record, 'grepPreviewMatches', config, warnings);
+  normalizePositiveInteger(record, 'globPreviewFiles', config, warnings);
+  normalizePositiveInteger(record, 'lsPreviewEntries', config, warnings);
+  normalizePositiveInteger(record, 'shellTailLines', config, warnings);
+  normalizePositiveInteger(record, 'readPreviewLines', config, warnings);
+  normalizePositiveInteger(record, 'writePreviewLines', config, warnings);
+  normalizePositiveInteger(record, 'webSearchPreviewChars', config, warnings);
+
+  return config;
+}
+
+export function loadToolDisplayConfig(
+  configPath = getToolDisplayConfigPath(),
+): LoadedToolDisplayConfig {
+  try {
+    if (!existsSync(configPath)) return { config: { ...DEFAULT_TOOL_DISPLAY_CONFIG } };
+    const parsed: unknown = JSON.parse(readFileSync(configPath, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {
+        config: { ...DEFAULT_TOOL_DISPLAY_CONFIG },
+        warning: `Config ${configPath} must be a JSON object. Using defaults.`,
+      };
+    }
+    const warnings: string[] = [];
+    const config = normalizeToolDisplayConfig(parsed as Partial<ToolDisplayConfig>, warnings);
+    return {
+      config,
+      warning: warnings.length ? `Invalid ${configPath}: ${warnings.join(' ')}` : undefined,
+    };
+  } catch (err) {
+    return {
+      config: { ...DEFAULT_TOOL_DISPLAY_CONFIG },
+      warning: `Could not read ${configPath}: ${err instanceof Error ? err.message : String(err)}. Using defaults.`,
+    };
+  }
+}
+
+export function saveToolDisplayConfig(
+  config: ToolDisplayConfig,
+  configPath = getToolDisplayConfigPath(),
+) {
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(normalizeToolDisplayConfig(config), null, 2));
+}
+
+function formatConfig(config: ToolDisplayConfig, warning?: string): string {
+  return [
+    `grok-cli-tools display: ${config.toolDisplay}`,
+    `grepPreviewMatches: ${config.grepPreviewMatches}`,
+    `globPreviewFiles: ${config.globPreviewFiles}`,
+    `lsPreviewEntries: ${config.lsPreviewEntries}`,
+    `shellTailLines: ${config.shellTailLines}`,
+    `readPreviewLines: ${config.readPreviewLines}`,
+    `writePreviewLines: ${config.writePreviewLines}`,
+    `webSearchPreviewChars: ${config.webSearchPreviewChars}`,
+    `config: ${getToolDisplayConfigPath()}`,
+    warning ? `warning: ${warning}` : undefined,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function registerModeCommand(pi: Pick<ExtensionAPI, 'registerCommand'>, mode: ToolDisplayMode) {
+  pi.registerCommand(`grok-cli-tools:${mode}`, {
+    description: `Set grok-cli tool display mode to ${mode}`,
+    handler: async (_args, ctx) => {
+      const config = configForToolDisplayMode(mode);
+      saveToolDisplayConfig(config);
+      ctx.ui.notify(formatConfig(config), 'info');
+    },
+  });
+}
+
+export function registerToolDisplayCommands(pi: Pick<ExtensionAPI, 'registerCommand'>) {
+  pi.registerCommand('grok-cli-tools:status', {
+    description: 'Show grok-cli tool display mode and preview limits',
+    handler: async (_args, ctx) => {
+      const { config, warning } = loadToolDisplayConfig();
+      ctx.ui.notify(formatConfig(config, warning), warning ? 'warning' : 'info');
+    },
+  });
+
+  registerModeCommand(pi, 'minimal');
+  registerModeCommand(pi, 'preview');
+}

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -10,7 +10,6 @@ import { dirname, resolve } from 'node:path';
 import { Type } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import {
-  argsFromRenderContext,
   booleanDetail,
   currentToolDisplayConfig,
   fileError,
@@ -41,7 +40,7 @@ type EditArgs = {
 
 type ToolTheme = {
   bold: (text: string) => string;
-  fg: (name: 'accent' | 'toolTitle', text: string) => string;
+  fg: (name: 'accent' | 'dim' | 'error' | 'muted' | 'toolTitle', text: string) => string;
 };
 
 function parseEditList(value: unknown): ReplacementEdit[] | undefined {
@@ -126,6 +125,34 @@ function renderReplacementResult(
 
 function renderPathToolCall(toolName: string, filePath: string, theme: ToolTheme) {
   return text(theme.fg('toolTitle', theme.bold(`${toolName} `)) + theme.fg('accent', filePath));
+}
+
+function writeCallPreviewLines(value: string, limit: number) {
+  if (limit <= 0) return [];
+  const normalized = value.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+  const lines = normalized.at(-1) === '' ? normalized.slice(0, -1) : normalized;
+  if (lines.length <= limit) return lines;
+  return [
+    ...lines.slice(0, limit),
+    `... (${lines.length - limit} more lines, ${lines.length} total)`,
+  ];
+}
+
+function renderWriteToolCall(
+  args: Record<string, unknown>,
+  theme: ToolTheme,
+  context?: { expanded?: boolean },
+) {
+  const call =
+    theme.fg('toolTitle', theme.bold('Write ')) + theme.fg('accent', stringFrom(args.path) ?? '');
+  const content = stringFrom(args.content) ?? stringFrom(args.contents);
+  if (!content) return text(call);
+  const lines = writeCallPreviewLines(
+    content,
+    context?.expanded ? Number.MAX_SAFE_INTEGER : currentToolDisplayConfig().writeCallPreviewLines,
+  );
+  if (lines.length === 0) return text(call);
+  return text(`${call}\n\n${theme.fg('dim', lines.join('\n'))}`);
 }
 
 type FileDetails = { path: string; [key: string]: unknown };
@@ -259,19 +286,18 @@ export function registerFileTools(pi: ExtensionAPI) {
         };
       }
     },
-    renderCall(args, theme) {
-      return renderPathToolCall('Write', args.path, theme);
+    renderCall(args, theme, context) {
+      return renderWriteToolCall(args, theme, context);
     },
     renderResult(result, { expanded, isPartial }, theme, context) {
-      return renderResultWithPreview(
+      if (isPartial) return text('Running...');
+      if (!booleanDetail(result, 'failed') && recordFrom(context)?.isError !== true)
+        return text('');
+      return renderResultSummary(
         result,
-        { expanded, isPartial },
-        theme.fg('muted', `${numberDetail(result, 'bytesWritten')} bytes written`),
-        previewLines(
-          stringFrom(argsFromRenderContext(context).content) ?? '',
-          currentToolDisplayConfig().writePreviewLines,
-        ),
-        theme,
+        expanded,
+        false,
+        theme.fg('error', firstText(result) ?? 'Write failed'),
       );
     },
   });

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -10,13 +10,18 @@ import { dirname, resolve } from 'node:path';
 import { Type } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import {
+  argsFromRenderContext,
   booleanDetail,
+  currentToolDisplayConfig,
   fileError,
   fileNotFound,
+  firstText,
   MAX_OUTPUT_CHARS,
   numberDetail,
+  previewLines,
   recordFrom,
   renderResultSummary,
+  renderResultWithPreview,
   stringDetail,
   stringFrom,
   type ToolError,
@@ -186,11 +191,12 @@ export function registerFileTools(pi: ExtensionAPI) {
       return renderPathToolCall('LS', args.path, theme);
     },
     renderResult(result, { expanded, isPartial }, theme) {
-      return renderResultSummary(
+      return renderResultWithPreview(
         result,
-        expanded,
-        isPartial,
+        { expanded, isPartial },
         theme.fg('muted', stringDetail(result, 'path')),
+        previewLines(firstText(result) ?? '', currentToolDisplayConfig().lsPreviewEntries),
+        theme,
       );
     },
   });
@@ -256,12 +262,16 @@ export function registerFileTools(pi: ExtensionAPI) {
     renderCall(args, theme) {
       return renderPathToolCall('Write', args.path, theme);
     },
-    renderResult(result, { expanded, isPartial }, theme) {
-      return renderResultSummary(
+    renderResult(result, { expanded, isPartial }, theme, context) {
+      return renderResultWithPreview(
         result,
-        expanded,
-        isPartial,
+        { expanded, isPartial },
         theme.fg('muted', `${numberDetail(result, 'bytesWritten')} bytes written`),
+        previewLines(
+          stringFrom(argsFromRenderContext(context).content) ?? '',
+          currentToolDisplayConfig().writePreviewLines,
+        ),
+        theme,
       );
     },
   });

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -40,7 +40,18 @@ type EditArgs = {
 
 type ToolTheme = {
   bold: (text: string) => string;
-  fg: (name: 'accent' | 'dim' | 'error' | 'muted' | 'toolTitle', text: string) => string;
+  fg: (
+    name:
+      | 'accent'
+      | 'dim'
+      | 'error'
+      | 'muted'
+      | 'toolDiffAdded'
+      | 'toolDiffContext'
+      | 'toolDiffRemoved'
+      | 'toolTitle',
+    text: string,
+  ) => string;
 };
 
 function parseEditList(value: unknown): ReplacementEdit[] | undefined {
@@ -106,21 +117,76 @@ function replacementResult(text: string, filePath: string) {
   };
 }
 
+function replacementSummary(replacements: number) {
+  if (replacements === 0) return 'No replacements';
+  return `${replacements} ${replacements === 1 ? 'replacement' : 'replacements'}`;
+}
+
+function splitDisplayLines(value: string) {
+  const lines = value.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+  return lines.at(-1) === '' ? lines.slice(0, -1) : lines;
+}
+
+function generateDisplayDiff(oldContent: string, newContent: string, contextLines = 2) {
+  if (oldContent === newContent) return '';
+  const oldLines = splitDisplayLines(oldContent);
+  const newLines = splitDisplayLines(newContent);
+  const firstChanged = oldLines.findIndex((line, index) => line !== newLines[index]);
+  const changeStart =
+    firstChanged === -1 ? Math.min(oldLines.length, newLines.length) : firstChanged;
+  const maxSuffix = Math.min(oldLines.length - changeStart, newLines.length - changeStart);
+  const commonSuffix = Array.from({ length: maxSuffix }).findIndex(
+    (_, index) => oldLines.at(-index - 1) !== newLines.at(-index - 1),
+  );
+  const suffixLength = commonSuffix === -1 ? maxSuffix : commonSuffix;
+  const oldChangeEnd = oldLines.length - suffixLength;
+  const newChangeEnd = newLines.length - suffixLength;
+  const beforeStart = Math.max(0, changeStart - contextLines);
+  const afterEnd = Math.min(oldLines.length, oldChangeEnd + contextLines);
+
+  return [
+    ...oldLines
+      .slice(beforeStart, changeStart)
+      .map((line, index) => ` ${beforeStart + index + 1} ${line}`),
+    ...oldLines
+      .slice(changeStart, oldChangeEnd)
+      .map((line, index) => `-${changeStart + index + 1} ${line}`),
+    ...newLines
+      .slice(changeStart, newChangeEnd)
+      .map((line, index) => `+${changeStart + index + 1} ${line}`),
+    ...oldLines
+      .slice(oldChangeEnd, afterEnd)
+      .map((line, index) => ` ${oldChangeEnd + index + 1} ${line}`),
+  ].join('\n');
+}
+
+function renderDisplayDiff(diff: string, theme: ToolTheme) {
+  return diff
+    .split('\n')
+    .map((line) => {
+      if (line.startsWith('+')) return theme.fg('toolDiffAdded', line);
+      if (line.startsWith('-')) return theme.fg('toolDiffRemoved', line);
+      return theme.fg('toolDiffContext', line);
+    })
+    .join('\n');
+}
+
 function renderReplacementResult(
   result: { content: { type: string; text?: string }[]; details: unknown },
   expanded: boolean,
   isPartial: boolean,
-  theme: { fg: (name: 'dim' | 'muted', text: string) => string },
+  theme: ToolTheme,
 ) {
   const replacements = numberDetail(result, 'replacements');
-  return renderResultSummary(
-    result,
-    expanded,
-    isPartial,
+  const summary =
     replacements === 0
-      ? theme.fg('dim', 'No replacements')
-      : theme.fg('muted', `${replacements} replacement(s)`),
-  );
+      ? theme.fg('dim', replacementSummary(replacements))
+      : theme.fg('muted', replacementSummary(replacements));
+  const diff = stringDetail(result, 'diff');
+  if (isPartial || replacements === 0 || !diff) {
+    return renderResultSummary(result, expanded, isPartial, summary);
+  }
+  return text(`${renderDisplayDiff(diff, theme)}\n\n${summary}`);
 }
 
 function renderPathToolCall(toolName: string, filePath: string, theme: ToolTheme) {
@@ -373,7 +439,11 @@ export function registerFileTools(pi: ExtensionAPI) {
               text: `Replaced ${count} occurrence(s) in ${params.path}`,
             },
           ],
-          details: { path: resolved, replacements: count },
+          details: {
+            path: resolved,
+            replacements: count,
+            diff: generateDisplayDiff(content, newContent),
+          },
         };
       } catch (error: unknown) {
         return fileError(error, 'StrReplace', filePath, { replacements: 0 });

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -131,6 +131,40 @@ function generateDisplayDiff(oldContent: string, newContent: string, contextLine
   if (oldContent === newContent) return '';
   const oldLines = splitDisplayLines(oldContent);
   const newLines = splitDisplayLines(newContent);
+
+  // Equal-length edits (typical replaceAll on whole lines): emit separate hunks so
+  // unchanged lines between replacements stay context instead of one giant replace span.
+  if (oldLines.length === newLines.length) {
+    const changed = oldLines.flatMap((line, index) => (line === newLines[index] ? [] : [index]));
+    if (changed.length === 0) return '';
+
+    const show = new Set(
+      changed.flatMap((index) =>
+        Array.from(
+          {
+            length:
+              Math.min(oldLines.length - 1, index + contextLines) -
+              Math.max(0, index - contextLines) +
+              1,
+          },
+          (_, offset) => Math.max(0, index - contextLines) + offset,
+        ),
+      ),
+    );
+
+    return [...show]
+      .sort((a, b) => a - b)
+      .flatMap((index, position, indices) => {
+        const gap = position > 0 && index > (indices[position - 1] ?? index) + 1 ? ['...'] : [];
+        if (oldLines[index] !== newLines[index]) {
+          return [...gap, `-${index + 1} ${oldLines[index]}`, `+${index + 1} ${newLines[index]}`];
+        }
+        return [...gap, ` ${index + 1} ${oldLines[index]}`];
+      })
+      .join('\n');
+  }
+
+  // Unequal line counts: fall back to a single prefix/suffix span.
   const firstChanged = oldLines.findIndex((line, index) => line !== newLines[index]);
   const changeStart =
     firstChanged === -1 ? Math.min(oldLines.length, newLines.length) : firstChanged;
@@ -357,6 +391,8 @@ export function registerFileTools(pi: ExtensionAPI) {
     },
     renderResult(result, { expanded, isPartial }, theme, context) {
       if (isPartial) return text('Running...');
+      // Match native pi write: successful results stay empty in both collapsed and
+      // expanded views. Written content is shown on renderCall; result is for errors.
       if (!booleanDetail(result, 'failed') && recordFrom(context)?.isError !== true)
         return text('');
       return renderResultSummary(

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -1,11 +1,39 @@
 import { createReadToolDefinition, type ExtensionContext } from '@earendil-works/pi-coding-agent';
-import { recordFrom } from './rendering.js';
+import {
+  argsFromRenderContext,
+  currentToolDisplayConfig,
+  firstText,
+  previewLines,
+  recordFrom,
+  renderResultWithPreview,
+} from './rendering.js';
 
 type ReadInput = {
   path: string;
   offset?: number;
   limit?: number;
 };
+
+type Theme = { fg: (name: 'muted' | 'dim', text: string) => string };
+
+function readSummary(context: unknown) {
+  const args = argsFromRenderContext(context);
+  const path = typeof args.path === 'string' ? args.path : stringFromUnknown(args.file_path);
+  const offset = typeof args.offset === 'number' ? args.offset : undefined;
+  const limit = typeof args.limit === 'number' ? args.limit : undefined;
+  const range = [
+    offset === undefined ? undefined : `offset=${offset}`,
+    limit === undefined ? undefined : `limit=${limit}`,
+  ]
+    .filter(Boolean)
+    .join(', ');
+  if (!path) return 'Read complete';
+  return range ? `Read ${path} (${range})` : `Read ${path}`;
+}
+
+function stringFromUnknown(value: unknown) {
+  return typeof value === 'string' ? value : undefined;
+}
 
 /**
  * Cursor/Grok-trained models call a capital-`Read` tool. Rather than
@@ -15,9 +43,9 @@ type ReadInput = {
  *
  * The native `read` resolves paths against the `cwd` captured at construction
  * time (it does not read `ctx.cwd`), so `execute` rebuilds the definition per
- * call with the live `ctx.cwd`. Everything else — `parameters`, `description`,
- * `renderCall`, `renderResult`, prompt guidance — is delegated to the native
- * tool; only `name`/`label`/`prepareArguments` differ.
+ * call with the live `ctx.cwd`. The expanded result renderer delegates to the
+ * native tool; the collapsed renderer shows a configurable path summary and an
+ * optional short preview.
  */
 export function createReadShim() {
   const native = createReadToolDefinition(process.cwd());
@@ -49,6 +77,37 @@ export function createReadShim() {
         signal,
         onUpdate as never,
         ctx,
+      );
+    },
+    renderResult(
+      result: { content: { type: string; text?: string }[] },
+      options: { expanded: boolean; isPartial: boolean },
+      theme: Theme,
+      context: unknown,
+    ) {
+      if (options.expanded) {
+        return (
+          native.renderResult?.(
+            result as never,
+            options as never,
+            theme as never,
+            context as never,
+          ) ??
+          renderResultWithPreview(
+            result,
+            options,
+            theme.fg('muted', readSummary(context)),
+            [],
+            theme,
+          )
+        );
+      }
+      return renderResultWithPreview(
+        result,
+        options,
+        theme.fg('muted', readSummary(context)),
+        previewLines(firstText(result) ?? '', currentToolDisplayConfig().readPreviewLines),
+        theme,
       );
     },
   };

--- a/src/tools/rendering.ts
+++ b/src/tools/rendering.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import { basename, join, relative } from 'node:path';
 import { promisify } from 'node:util';
 import { Text } from '@earendil-works/pi-tui';
+import { loadToolDisplayConfig } from './displayConfig.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -18,6 +19,11 @@ export function recordFrom(value: unknown): Record<string, unknown> | undefined 
 export function stringFrom(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   return value;
+}
+
+export function argsFromRenderContext(value: unknown): Record<string, unknown> {
+  const context = recordFrom(value);
+  return recordFrom(context?.args) ?? context ?? {};
 }
 
 export function truncateLines(lines: string[]): string {
@@ -108,10 +114,40 @@ export function text(text: string): Text {
   return new Text(text, 0, 0);
 }
 
-function firstText(result: { content: { type: string; text?: string }[] }) {
+export function firstText(result: { content: { type: string; text?: string }[] }) {
   const first = result.content[0];
   if (first?.type !== 'text') return undefined;
   return first.text;
+}
+
+function normalizedLines(value: string): string[] {
+  const lines = value.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+  return lines.at(-1) === '' ? lines.slice(0, -1) : lines;
+}
+
+export function previewLines(
+  value: string,
+  limit: number,
+  direction: 'head' | 'tail' = 'head',
+): string[] {
+  if (limit <= 0) return [];
+  const lines = normalizedLines(value);
+  if (lines.length <= limit) return lines;
+  const selected = direction === 'tail' ? lines.slice(-limit) : lines.slice(0, limit);
+  return [
+    ...selected,
+    `[Showing ${direction === 'tail' ? 'last' : 'first'} ${selected.length} of ${lines.length} lines.]`,
+  ];
+}
+
+export function previewChars(value: string, limit: number): string {
+  if (limit <= 0) return '';
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit)}\n[Preview truncated at ${limit} characters.]`;
+}
+
+export function currentToolDisplayConfig() {
+  return loadToolDisplayConfig().config;
 }
 
 export function renderResultText(
@@ -121,6 +157,21 @@ export function renderResultText(
 ): Text {
   if (expanded) return text(firstText(result) ?? summary);
   return text(summary);
+}
+
+export function renderResultWithPreview(
+  result: { content: { type: string; text?: string }[] },
+  options: { expanded: boolean; isPartial: boolean },
+  summary: string,
+  preview: string | string[],
+  theme: { fg: (name: 'dim', text: string) => string },
+): Text {
+  const running = renderRunning(options.isPartial);
+  if (running) return running;
+  if (options.expanded) return renderResultText(result, true, summary);
+  const previewText = Array.isArray(preview) ? preview.join('\n') : preview;
+  if (!previewText) return text(summary);
+  return text(`${summary}\n${theme.fg('dim', previewText)}`);
 }
 
 export function renderRunning(isPartial: boolean): Text | undefined {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -5,16 +5,18 @@ import { promisify } from 'node:util';
 import { Type } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import {
+  currentToolDisplayConfig,
   execWithRgFallback,
+  firstText,
   globToRegExp,
   hasRipgrep,
   listFilesRecursive,
   MAX_OUTPUT_BYTES,
   normalizePath,
   numberDetail,
+  previewLines,
   recordFrom,
-  renderResultText,
-  renderRunning,
+  renderResultWithPreview,
   stringFrom,
   text,
   toolError,
@@ -119,15 +121,17 @@ export function registerSearchTools(pi: ExtensionAPI) {
       );
     },
     renderResult(result, { expanded, isPartial }, theme) {
-      const running = renderRunning(isPartial);
-      if (running) return running;
       const matchCount = numberDetail(result, 'matchCount');
-      return renderResultText(
+      return renderResultWithPreview(
         result,
-        expanded,
+        { expanded, isPartial },
         matchCount === 0
           ? theme.fg('dim', 'No matches')
           : theme.fg('muted', `${matchCount} match(es)`),
+        matchCount === 0
+          ? []
+          : previewLines(firstText(result) ?? '', currentToolDisplayConfig().grepPreviewMatches),
+        theme,
       );
     },
   });
@@ -211,13 +215,15 @@ export function registerSearchTools(pi: ExtensionAPI) {
       );
     },
     renderResult(result, { expanded, isPartial }, theme) {
-      const running = renderRunning(isPartial);
-      if (running) return running;
       const fileCount = numberDetail(result, 'fileCount');
-      return renderResultText(
+      return renderResultWithPreview(
         result,
-        expanded,
+        { expanded, isPartial },
         fileCount === 0 ? theme.fg('dim', 'No files') : theme.fg('muted', `${fileCount} file(s)`),
+        fileCount === 0
+          ? []
+          : previewLines(firstText(result) ?? '', currentToolDisplayConfig().globPreviewFiles),
+        theme,
       );
     },
   });

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -5,11 +5,13 @@ import { promisify } from 'node:util';
 import { Type } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import {
+  currentToolDisplayConfig,
   detailRecord,
+  firstText,
   MAX_OUTPUT_BYTES,
   MAX_OUTPUT_CHARS,
-  renderResultText,
-  renderRunning,
+  previewLines,
+  renderResultWithPreview,
   text,
 } from './rendering.js';
 
@@ -145,14 +147,14 @@ export function registerShellTool(pi: ExtensionAPI) {
       );
     },
     renderResult(result, { expanded, isPartial }, theme) {
-      const running = renderRunning(isPartial);
-      if (running) return running;
       const exitCode =
         typeof detailRecord(result).exitCode === 'number' ? detailRecord(result).exitCode : 1;
-      return renderResultText(
+      return renderResultWithPreview(
         result,
-        expanded,
+        { expanded, isPartial },
         exitCode === 0 ? theme.fg('muted', 'Exit 0') : theme.fg('warning', `Exit ${exitCode}`),
+        previewLines(firstText(result) ?? '', currentToolDisplayConfig().shellTailLines, 'tail'),
+        theme,
       );
     },
   });

--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -1,7 +1,13 @@
 import { StringEnum, Type } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Text } from '@earendil-works/pi-tui';
-import { renderRunning, text } from './rendering.js';
+import {
+  currentToolDisplayConfig,
+  firstText,
+  previewChars,
+  renderRunning,
+  text,
+} from './rendering.js';
 import {
   ensureWebSearchDelegate,
   getWebSearchDelegate,
@@ -148,9 +154,12 @@ export function registerWebSearchTool(pi: ExtensionAPI) {
           ? theme.fg('success', `${details.totalResults} sources`)
           : theme.fg('success', 'search complete');
 
-      if (!expanded) return text(summary);
+      const textContent = firstText(result) ?? '';
+      if (!expanded) {
+        const preview = previewChars(textContent, currentToolDisplayConfig().webSearchPreviewChars);
+        return preview ? new Text(`${summary}\n${theme.fg('dim', preview)}`, 0, 0) : text(summary);
+      }
 
-      const textContent = result.content.find((c) => c.type === 'text')?.text ?? '';
       const preview = textContent.length > 800 ? `${textContent.slice(0, 800)}...` : textContent;
       return new Text(`${summary}\n${theme.fg('dim', preview)}`, 0, 0);
     },

--- a/tests/provider/package.test.ts
+++ b/tests/provider/package.test.ts
@@ -66,6 +66,7 @@ describe('repository layout', () => {
       'src/provider/toolScope.ts',
       'src/provider/usage.ts',
       'src/shared/errors.ts',
+      'src/tools/displayConfig.ts',
       'src/tools/files.ts',
       'src/tools/read.ts',
       'src/tools/register.ts',

--- a/tests/provider/register.test.ts
+++ b/tests/provider/register.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Api, Model, OAuthCredentials, OAuthProviderInterface } from '@earendil-works/pi-ai';
@@ -56,6 +56,7 @@ const originalFetch = globalThis.fetch;
 const originalHome = process.env.HOME;
 const originalTimeZone = process.env.TZ;
 const originalToken = process.env.GROK_CLI_OAUTH_TOKEN;
+const originalToolDisplayConfig = process.env.PI_GROK_CLI_TOOLS_CONFIG;
 const tempDirs: string[] = [];
 
 beforeEach(() => {
@@ -84,10 +85,18 @@ afterEach(() => {
   } else {
     process.env.GROK_CLI_OAUTH_TOKEN = originalToken;
   }
+  if (originalToolDisplayConfig === undefined) {
+    delete process.env.PI_GROK_CLI_TOOLS_CONFIG;
+  } else {
+    process.env.PI_GROK_CLI_TOOLS_CONFIG = originalToolDisplayConfig;
+  }
   for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true });
 });
 
 async function setupExtension(initialActiveTools = ['read', 'bash'], piWebAccessInstalled = true) {
+  const configDir = mkdtempSync(join(tmpdir(), 'pi-grok-cli-tool-display-'));
+  tempDirs.push(configDir);
+  process.env.PI_GROK_CLI_TOOLS_CONFIG = join(configDir, 'missing.json');
   vi.spyOn(webSearchDelegate, 'isPiWebAccessInstalled').mockReturnValue(piWebAccessInstalled);
   const commands = new Map<string, CommandConfig>();
   const providers = new Map<string, ProviderConfig>();
@@ -145,6 +154,13 @@ function contextForModel(provider: string): TestContext {
     model: { provider, id: `${provider}-model` },
     modelRegistry: { getAll: () => [] },
     ui: { notify: vi.fn() },
+  };
+}
+
+function commandContext(notify: TestContext['ui']['notify']): TestContext {
+  return {
+    modelRegistry: { getAll: () => [] },
+    ui: { notify },
   };
 }
 
@@ -461,6 +477,24 @@ describe('Grok CLI status command', () => {
   });
 });
 
+describe('Grok CLI tool display commands', () => {
+  it('registers status and mode commands that persist display config', async () => {
+    const extension = await setupExtension();
+    const notify = vi.fn();
+
+    await extension.commands.get('grok-cli-tools:preview')?.handler([], commandContext(notify));
+
+    expect(notify.mock.calls.at(-1)?.[0]).toContain('grok-cli-tools display: preview');
+    expect(
+      JSON.parse(readFileSync(process.env.PI_GROK_CLI_TOOLS_CONFIG ?? '', 'utf-8')).toolDisplay,
+    ).toBe('preview');
+
+    await extension.commands.get('grok-cli-tools:status')?.handler([], commandContext(notify));
+
+    expect(notify.mock.calls.at(-1)?.[0]).toContain('grok-cli-tools display: preview');
+  });
+});
+
 describe('Grok CLI provider registration', () => {
   it('registers provider metadata and OAuth helpers', async () => {
     const extension = await setupExtension();
@@ -649,7 +683,7 @@ describe('Grok CLI tool rendering', () => {
     }
   });
 
-  it('keeps collapsed search output compact and expands to full output', async () => {
+  it('shows preview collapsed search output and expands to full output', async () => {
     const extension = await setupExtension();
     const grep = extension.tools.get('Grep');
     const result = {
@@ -664,8 +698,7 @@ describe('Grok CLI tool rendering', () => {
       grep?.renderResult?.(result, { expanded: true, isPartial: false }, theme, {}) as Renderable,
     );
 
-    expect(collapsed).toBe('2 match(es)');
-    expect(collapsed).not.toContain('src/a.ts');
+    expect(collapsed).toBe('2 match(es)\nsrc/a.ts:1:match\nsrc/b.ts:2:match');
     expect(expanded).toContain('src/a.ts:1:match');
   });
 
@@ -723,6 +756,6 @@ describe('Grok CLI tool rendering', () => {
           {},
         ) as Renderable,
       ),
-    ).toBe('Exit 2');
+    ).toBe('Exit 2\nlong shell output');
   });
 });

--- a/tests/provider/register.test.ts
+++ b/tests/provider/register.test.ts
@@ -741,7 +741,7 @@ describe('Grok CLI tool rendering', () => {
           {},
         ) as Renderable,
       ),
-    ).toBe('3 replacement(s)');
+    ).toBe('3 replacements');
     expect(
       renderText(
         extension.tools.get('Delete')?.renderResult?.(

--- a/tests/provider/register.test.ts
+++ b/tests/provider/register.test.ts
@@ -707,6 +707,17 @@ describe('Grok CLI tool rendering', () => {
 
     expect(
       renderText(
+        extension.tools
+          .get('Write')
+          ?.renderCall?.(
+            { path: 'notes.txt', content: 'alpha\nbeta\ngamma' },
+            theme,
+            {},
+          ) as Renderable,
+      ),
+    ).toBe('Write notes.txt\n\nalpha\nbeta\ngamma');
+    expect(
+      renderText(
         extension.tools.get('Write')?.renderResult?.(
           {
             content: [{ type: 'text', text: 'long write output' }],
@@ -717,7 +728,7 @@ describe('Grok CLI tool rendering', () => {
           {},
         ) as Renderable,
       ),
-    ).toBe('42 bytes written');
+    ).toBe('');
     expect(
       renderText(
         extension.tools.get('StrReplace')?.renderResult?.(

--- a/tests/tools/displayConfig.test.ts
+++ b/tests/tools/displayConfig.test.ts
@@ -27,11 +27,13 @@ describe('tool display config', () => {
         toolDisplay: 'preview',
         shellTailLines: 12,
         readPreviewLines: 2,
+        writeCallPreviewLines: 8,
       }),
     ).toEqual({
       ...configForToolDisplayMode('preview'),
       shellTailLines: 12,
       readPreviewLines: 2,
+      writeCallPreviewLines: 8,
     });
   });
 

--- a/tests/tools/displayConfig.test.ts
+++ b/tests/tools/displayConfig.test.ts
@@ -43,6 +43,13 @@ describe('tool display config', () => {
 
     expect(loadToolDisplayConfig(invalidJsonPath).warning).toMatch(/Could not read/);
 
+    const nonObjectPath = join(tempDir('pi-grok-cli-tools-config-'), 'array.json');
+    writeFileSync(nonObjectPath, '[]', 'utf-8');
+    expect(loadToolDisplayConfig(nonObjectPath)).toEqual({
+      config: DEFAULT_TOOL_DISPLAY_CONFIG,
+      warning: `Config ${nonObjectPath} must be a JSON object. Using defaults.`,
+    });
+
     const warnings: string[] = [];
     const config = normalizeToolDisplayConfig(
       { toolDisplay: 'maximal' as never, grepPreviewMatches: -1 },

--- a/tests/tools/displayConfig.test.ts
+++ b/tests/tools/displayConfig.test.ts
@@ -1,0 +1,76 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  configForToolDisplayMode,
+  DEFAULT_TOOL_DISPLAY_CONFIG,
+  getToolDisplayConfigPath,
+  loadToolDisplayConfig,
+  normalizeToolDisplayConfig,
+  saveToolDisplayConfig,
+} from '../../src/tools/displayConfig.js';
+import { tempDir } from './toolTestHelpers.js';
+
+describe('tool display config', () => {
+  it('uses preview defaults when the config file is missing', () => {
+    const path = join(tempDir('pi-grok-cli-tools-config-'), 'missing.json');
+
+    expect(loadToolDisplayConfig(path)).toEqual({ config: DEFAULT_TOOL_DISPLAY_CONFIG });
+  });
+
+  it('uses mode-specific defaults and numeric overrides', () => {
+    expect(normalizeToolDisplayConfig({ toolDisplay: 'minimal' })).toEqual(
+      configForToolDisplayMode('minimal'),
+    );
+    expect(
+      normalizeToolDisplayConfig({
+        toolDisplay: 'preview',
+        shellTailLines: 12,
+        readPreviewLines: 2,
+      }),
+    ).toEqual({
+      ...configForToolDisplayMode('preview'),
+      shellTailLines: 12,
+      readPreviewLines: 2,
+    });
+  });
+
+  it('reports invalid files and values while falling back safely', () => {
+    const invalidJsonPath = join(tempDir('pi-grok-cli-tools-config-'), 'invalid.json');
+    writeFileSync(invalidJsonPath, '{', 'utf-8');
+
+    expect(loadToolDisplayConfig(invalidJsonPath).warning).toMatch(/Could not read/);
+
+    const warnings: string[] = [];
+    const config = normalizeToolDisplayConfig(
+      { toolDisplay: 'maximal' as never, grepPreviewMatches: -1 },
+      warnings,
+    );
+    expect(config.toolDisplay).toBe('preview');
+    expect(config.grepPreviewMatches).toBe(DEFAULT_TOOL_DISPLAY_CONFIG.grepPreviewMatches);
+    expect(warnings.join('\n')).toMatch(/toolDisplay/);
+    expect(warnings.join('\n')).toMatch(/grepPreviewMatches/);
+  });
+
+  it('saves normalized config files', () => {
+    const path = join(tempDir('pi-grok-cli-tools-config-'), '.pi', 'grok-cli-tools.json');
+    const config = configForToolDisplayMode('minimal');
+
+    saveToolDisplayConfig(config, path);
+
+    expect(existsSync(path)).toBe(true);
+    expect(JSON.parse(readFileSync(path, 'utf-8'))).toEqual(config);
+  });
+
+  it('supports an environment override for the config path', () => {
+    const original = process.env.PI_GROK_CLI_TOOLS_CONFIG;
+    const path = join(tempDir('pi-grok-cli-tools-config-'), 'custom.json');
+    process.env.PI_GROK_CLI_TOOLS_CONFIG = path;
+    try {
+      expect(getToolDisplayConfigPath()).toBe(path);
+    } finally {
+      if (original === undefined) delete process.env.PI_GROK_CLI_TOOLS_CONFIG;
+      else process.env.PI_GROK_CLI_TOOLS_CONFIG = original;
+    }
+  });
+});

--- a/tests/tools/files.test.ts
+++ b/tests/tools/files.test.ts
@@ -14,7 +14,7 @@ import {
 } from './toolTestHelpers.js';
 
 function expectStoryState(result: ToolResult, cwd: string, replacements: number, content: string) {
-  expect(result.details).toEqual({
+  expect(result.details).toMatchObject({
     path: expectedPath(cwd, 'story.txt'),
     replacements,
   });
@@ -199,6 +199,7 @@ describe('file tools', () => {
 
     expect(firstText(result)).toBe('Replaced 2 occurrence(s) in story.txt');
     expectStoryState(result, cwd, 2, 'green blue green');
+    expect(result.details.diff).toBe('-1 red blue red\n+1 green blue green');
   });
 
   it('rejects empty replacement search strings without changing files', async () => {
@@ -452,6 +453,12 @@ describe('file tools', () => {
     );
     expect(renderToolCall(tools.get('Edit'), { path: 'notes.txt' })).toBe('Edit notes.txt');
     expect(renderToolCall(tools.get('Delete'), { path: 'notes.txt' })).toBe('Delete notes.txt');
+    expect(
+      renderToolResult(tools.get('StrReplace'), {
+        content: [{ type: 'text', text: 'replacement' }],
+        details: { replacements: 1, diff: ' 1 before\n-2 old\n+2 new\n 3 after' },
+      }),
+    ).toBe(' 1 before\n-2 old\n+2 new\n 3 after\n\n1 replacement');
     expect(
       renderToolResult(tools.get('StrReplace'), {
         content: [{ type: 'text', text: 'no replacement' }],

--- a/tests/tools/files.test.ts
+++ b/tests/tools/files.test.ts
@@ -202,6 +202,19 @@ describe('file tools', () => {
     expect(result.details.diff).toBe('-1 red blue red\n+1 green blue green');
   });
 
+  it('includes surrounding context lines in StrReplace diffs', async () => {
+    const cwd = tempDir('pi-grok-cli-files-');
+    writeFileSync(join(cwd, 'story.txt'), 'alpha\nbeta\ngamma\ndelta\nepsilon', 'utf-8');
+
+    const result = await executeTool(
+      collectTools(registerFileTools).get('StrReplace'),
+      { path: 'story.txt', old_str: 'gamma', new_str: 'GAMMA' },
+      cwd,
+    );
+
+    expect(result.details.diff).toBe(' 1 alpha\n 2 beta\n-3 gamma\n+3 GAMMA\n 4 delta\n 5 epsilon');
+  });
+
   it('rejects empty replacement search strings without changing files', async () => {
     const cwd = tempDir('pi-grok-cli-files-');
     writeFileSync(join(cwd, 'story.txt'), 'red blue red', 'utf-8');
@@ -476,7 +489,7 @@ describe('file tools', () => {
         content: [{ type: 'text', text: 'edited' }],
         details: { replacements: 2 },
       }),
-    ).toBe('2 replacement(s)');
+    ).toBe('2 replacements');
     expect(
       renderToolResult(
         tools.get('LS'),

--- a/tests/tools/files.test.ts
+++ b/tests/tools/files.test.ts
@@ -215,6 +215,38 @@ describe('file tools', () => {
     expect(result.details.diff).toBe(' 1 alpha\n 2 beta\n-3 gamma\n+3 GAMMA\n 4 delta\n 5 epsilon');
   });
 
+  it('keeps non-contiguous StrReplace hunks separate with context', async () => {
+    const cwd = tempDir('pi-grok-cli-files-');
+    writeFileSync(
+      join(cwd, 'story.txt'),
+      ['a', 'target', 'b', 'c', 'd', 'e', 'f', 'g', 'target', 'h'].join('\n'),
+      'utf-8',
+    );
+
+    const result = await executeTool(
+      collectTools(registerFileTools).get('StrReplace'),
+      { path: 'story.txt', old_str: 'target', new_str: 'TARGET' },
+      cwd,
+    );
+
+    expect(result.details.replacements).toBe(2);
+    expect(result.details.diff).toBe(
+      [
+        ' 1 a',
+        '-2 target',
+        '+2 TARGET',
+        ' 3 b',
+        ' 4 c',
+        '...',
+        ' 7 f',
+        ' 8 g',
+        '-9 target',
+        '+9 TARGET',
+        ' 10 h',
+      ].join('\n'),
+    );
+  });
+
   it('rejects empty replacement search strings without changing files', async () => {
     const cwd = tempDir('pi-grok-cli-files-');
     writeFileSync(join(cwd, 'story.txt'), 'red blue red', 'utf-8');
@@ -505,6 +537,16 @@ describe('file tools', () => {
         content: [{ type: 'text', text: 'writing' }],
         details: { bytesWritten: 10 },
       }),
+    ).toBe('');
+    expect(
+      renderToolResult(
+        tools.get('Write'),
+        {
+          content: [{ type: 'text', text: 'Successfully wrote 10 bytes to notes.txt' }],
+          details: { bytesWritten: 10 },
+        },
+        { expanded: true, isPartial: false },
+      ),
     ).toBe('');
     expect(
       renderToolResult(tools.get('Write'), {

--- a/tests/tools/files.test.ts
+++ b/tests/tools/files.test.ts
@@ -432,6 +432,21 @@ describe('file tools', () => {
 
     expect(renderToolCall(tools.get('LS'), { path: '.' })).toBe('LS .');
     expect(renderToolCall(tools.get('Write'), { path: 'notes.txt' })).toBe('Write notes.txt');
+    expect(
+      renderToolCall(tools.get('Write'), {
+        path: 'notes.txt',
+        content: Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join('\n'),
+      }),
+    ).toBe(
+      'Write notes.txt\n\nline 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10\n... (2 more lines, 12 total)',
+    );
+    expect(
+      renderToolCall(
+        tools.get('Write'),
+        { path: 'notes.txt', content: 'line 1\nline 2\nline 3' },
+        { expanded: true },
+      ),
+    ).toBe('Write notes.txt\n\nline 1\nline 2\nline 3');
     expect(renderToolCall(tools.get('StrReplace'), { path: 'notes.txt' })).toBe(
       'StrReplace notes.txt',
     );
@@ -465,6 +480,18 @@ describe('file tools', () => {
         { expanded: true, isPartial: false },
       ),
     ).toBe('full listing');
+    expect(
+      renderToolResult(tools.get('Write'), {
+        content: [{ type: 'text', text: 'writing' }],
+        details: { bytesWritten: 10 },
+      }),
+    ).toBe('');
+    expect(
+      renderToolResult(tools.get('Write'), {
+        content: [{ type: 'text', text: 'Write error: denied' }],
+        details: { failed: true },
+      }),
+    ).toBe('Write error: denied');
     expect(
       renderToolResult(
         tools.get('Write'),

--- a/tests/tools/read.test.ts
+++ b/tests/tools/read.test.ts
@@ -1,12 +1,14 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { saveToolDisplayConfig } from '../../src/tools/displayConfig.js';
 import { createReadShim } from '../../src/tools/read.js';
 import {
   executePreparedTool,
   executeTool,
   firstText,
   prepareToolArguments,
+  renderToolResult,
   type ToolResult,
   tempDir,
 } from './toolTestHelpers.js';
@@ -68,5 +70,95 @@ describe('Read shim (native read alias)', () => {
       cwd,
     )) as ToolResult;
     expect(firstText(result)).toContain('once upon a time');
+  });
+
+  it('summarizes collapsed results with path, range, and optional preview', () => {
+    const result = {
+      content: [{ type: 'text', text: 'line 1\nline 2\nline 3' }],
+      details: {},
+    };
+
+    expect(
+      renderToolResult(
+        readShim,
+        result,
+        { expanded: false, isPartial: false },
+        {
+          args: { path: 'notes.txt' },
+        },
+      ),
+    ).toBe('Read notes.txt');
+
+    expect(
+      renderToolResult(
+        readShim,
+        result,
+        { expanded: false, isPartial: false },
+        {
+          args: { file_path: 'src/app.ts', offset: 10, limit: 20 },
+        },
+      ),
+    ).toBe('Read src/app.ts (offset=10, limit=20)');
+
+    expect(renderToolResult(readShim, result, { expanded: false, isPartial: false }, {})).toBe(
+      'Read complete',
+    );
+
+    expect(
+      renderToolResult(
+        readShim,
+        result,
+        { expanded: false, isPartial: true },
+        {
+          args: { path: 'notes.txt' },
+        },
+      ),
+    ).toBe('Running...');
+
+    const previousConfigPath = process.env.PI_GROK_CLI_TOOLS_CONFIG;
+    process.env.PI_GROK_CLI_TOOLS_CONFIG = join(tempDir('pi-grok-cli-read-config-'), 'tools.json');
+    try {
+      saveToolDisplayConfig({
+        toolDisplay: 'preview',
+        grepPreviewMatches: 10,
+        globPreviewFiles: 20,
+        lsPreviewEntries: 20,
+        shellTailLines: 20,
+        readPreviewLines: 2,
+        writeCallPreviewLines: 10,
+        webSearchPreviewChars: 500,
+      });
+
+      expect(
+        renderToolResult(
+          readShim,
+          result,
+          { expanded: false, isPartial: false },
+          {
+            args: { path: 'notes.txt' },
+          },
+        ),
+      ).toBe('Read notes.txt\nline 1\nline 2\n[Showing first 2 of 3 lines.]');
+    } finally {
+      process.env.PI_GROK_CLI_TOOLS_CONFIG = previousConfigPath;
+    }
+  });
+
+  it('delegates expanded results to the native read renderer', () => {
+    const result = {
+      content: [{ type: 'text', text: 'alpha\nbeta' }],
+      details: {},
+    };
+
+    expect(
+      renderToolResult(
+        readShim,
+        result,
+        { expanded: true, isPartial: false },
+        {
+          args: { path: 'notes.txt' },
+        },
+      ),
+    ).toContain('alpha');
   });
 });

--- a/tests/tools/rendering.test.ts
+++ b/tests/tools/rendering.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  argsFromRenderContext,
   booleanDetail,
   detailRecord,
   fileError,
@@ -8,8 +9,11 @@ import {
   MAX_LINES,
   MAX_OUTPUT_CHARS,
   numberDetail,
+  previewChars,
+  previewLines,
   renderResultSummary,
   renderResultText,
+  renderResultWithPreview,
   renderRunning,
   stringDetail,
   text,
@@ -17,7 +21,7 @@ import {
   truncateChars,
   truncateLines,
 } from '../../src/tools/rendering.js';
-import { renderText } from './toolTestHelpers.js';
+import { plainTheme, renderText } from './toolTestHelpers.js';
 
 describe('tool rendering helpers', () => {
   it('truncates long result lists and large output', () => {
@@ -54,6 +58,89 @@ describe('tool rendering helpers', () => {
     expect(renderText(renderRunning(true) ?? text(''))).toBe('Running...');
     expect(renderRunning(false)).toBeUndefined();
     expect(renderText(renderResultSummary(result, false, true, 'summary'))).toBe('Running...');
+  });
+
+  it('extracts args from render contexts and builds previews', () => {
+    expect(argsFromRenderContext({ args: { path: 'a.txt' } })).toEqual({ path: 'a.txt' });
+    expect(argsFromRenderContext({ path: 'b.txt' })).toEqual({ path: 'b.txt' });
+    expect(argsFromRenderContext(null)).toEqual({});
+
+    expect(previewLines('one\ntwo\nthree', 0)).toEqual([]);
+    expect(previewLines('one\ntwo\nthree', 10)).toEqual(['one', 'two', 'three']);
+    expect(previewLines('one\ntwo\nthree\nfour', 2)).toEqual([
+      'one',
+      'two',
+      '[Showing first 2 of 4 lines.]',
+    ]);
+    expect(previewLines('one\ntwo\nthree\nfour', 2, 'tail')).toEqual([
+      'three',
+      'four',
+      '[Showing last 2 of 4 lines.]',
+    ]);
+
+    expect(previewChars('short', 0)).toBe('');
+    expect(previewChars('short', 10)).toBe('short');
+    expect(previewChars('abcdefghij', 4)).toBe('abcd\n[Preview truncated at 4 characters.]');
+
+    const result = {
+      content: [{ type: 'text', text: 'full output' }],
+      details: {},
+    };
+    expect(
+      renderText(
+        renderResultWithPreview(
+          result,
+          { expanded: false, isPartial: true },
+          'summary',
+          ['preview'],
+          plainTheme,
+        ),
+      ),
+    ).toBe('Running...');
+    expect(
+      renderText(
+        renderResultWithPreview(
+          result,
+          { expanded: true, isPartial: false },
+          'summary',
+          ['preview'],
+          plainTheme,
+        ),
+      ),
+    ).toBe('full output');
+    expect(
+      renderText(
+        renderResultWithPreview(
+          result,
+          { expanded: false, isPartial: false },
+          'summary',
+          [],
+          plainTheme,
+        ),
+      ),
+    ).toBe('summary');
+    expect(
+      renderText(
+        renderResultWithPreview(
+          result,
+          { expanded: false, isPartial: false },
+          'summary',
+          ['line a', 'line b'],
+          plainTheme,
+        ),
+      ),
+    ).toBe('summary\nline a\nline b');
+    expect(
+      renderText(
+        renderResultWithPreview(
+          result,
+          { expanded: false, isPartial: false },
+          'summary',
+          'string preview',
+          plainTheme,
+        ),
+      ),
+    ).toBe('summary\nstring preview');
   });
 
   it('reads typed detail values with defaults for absent or invalid details', () => {

--- a/tests/tools/search.test.ts
+++ b/tests/tools/search.test.ts
@@ -302,7 +302,7 @@ describe('search tools', () => {
           render: () => [],
         },
       ),
-    ).toBe('1 match(es)');
+    ).toBe('1 match(es)\nsrc/alpha.ts:1:needle');
     expect(
       renderText(
         grep?.renderResult?.(result, { expanded: true, isPartial: false }, plainTheme, {}) ?? {
@@ -352,7 +352,7 @@ describe('search tools', () => {
           render: () => [],
         },
       ),
-    ).toBe('2 file(s)');
+    ).toBe('2 file(s)\nsrc/alpha.ts\nsrc/gamma.ts');
     expect(
       renderText(
         glob?.renderResult?.(

--- a/tests/tools/shell.test.ts
+++ b/tests/tools/shell.test.ts
@@ -131,13 +131,13 @@ describe('shell tool', () => {
         content: [{ type: 'text', text: 'full output' }],
         details: { exitCode: 0 },
       }),
-    ).toBe('Exit 0');
+    ).toBe('Exit 0\nfull output');
     expect(
       renderToolResult(shell, {
         content: [{ type: 'text', text: 'spawn failed' }],
         details: { exitCode: 'ENOENT' },
       }),
-    ).toBe('Exit 1');
+    ).toBe('Exit 1\nspawn failed');
     expect(
       renderToolResult(
         shell,

--- a/tests/tools/toolTestHelpers.ts
+++ b/tests/tools/toolTestHelpers.ts
@@ -127,11 +127,12 @@ export function renderToolResult(
   tool: RegisteredTool | undefined,
   result: ToolResult,
   state = { expanded: false, isPartial: false },
+  context: Record<string, unknown> = {},
 ) {
   if (!tool?.renderResult) {
     throw new Error('Tool result renderer was not registered');
   }
-  return renderText(tool.renderResult(result, state, plainTheme, {}));
+  return renderText(tool.renderResult(result, state, plainTheme, context));
 }
 
 export function tempDir(prefix: string) {

--- a/tests/tools/toolTestHelpers.ts
+++ b/tests/tools/toolTestHelpers.ts
@@ -2,11 +2,20 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
-import { afterEach } from 'vitest';
+import { afterEach, beforeEach } from 'vitest';
 
 const tempDirs: string[] = [];
+const defaultToolDisplayConfigDir = mkdtempSync(join(tmpdir(), 'pi-grok-cli-tool-display-'));
+const defaultToolDisplayConfigPath = join(defaultToolDisplayConfigDir, 'missing.json');
+
+tempDirs.push(defaultToolDisplayConfigDir);
+
+beforeEach(() => {
+  process.env.PI_GROK_CLI_TOOLS_CONFIG = defaultToolDisplayConfigPath;
+});
 
 afterEach(() => {
+  process.env.PI_GROK_CLI_TOOLS_CONFIG = defaultToolDisplayConfigPath;
   for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true });
 });
 

--- a/tests/tools/toolTestHelpers.ts
+++ b/tests/tools/toolTestHelpers.ts
@@ -43,7 +43,11 @@ type RegisteredTool = {
     onUpdate: () => void,
     ctx: { cwd: string },
   ) => Promise<ToolResult>;
-  renderCall?: (args: Record<string, unknown>, theme: ToolTheme) => Renderable;
+  renderCall?: (
+    args: Record<string, unknown>,
+    theme: ToolTheme,
+    context?: Record<string, unknown>,
+  ) => Renderable;
   renderResult?: (
     result: ToolResult,
     state: { expanded: boolean; isPartial: boolean },
@@ -110,9 +114,13 @@ export const plainTheme = {
   fg: (_name: string, text: string) => text,
 };
 
-export function renderToolCall(tool: RegisteredTool | undefined, args: Record<string, unknown>) {
+export function renderToolCall(
+  tool: RegisteredTool | undefined,
+  args: Record<string, unknown>,
+  context: Record<string, unknown> = {},
+) {
   if (!tool?.renderCall) throw new Error('Tool call renderer was not registered');
-  return renderText(tool.renderCall(args, plainTheme));
+  return renderText(tool.renderCall(args, plainTheme, context));
 }
 
 export function renderToolResult(

--- a/tests/tools/webSearch.test.ts
+++ b/tests/tools/webSearch.test.ts
@@ -168,7 +168,7 @@ describe('WebSearch tool', () => {
         content: [{ type: 'text', text: 'synthesized answer' }],
         details: { totalResults: 12 },
       };
-      expect(renderToolResult(ws, result)).toBe('12 sources');
+      expect(renderToolResult(ws, result)).toBe('12 sources\nsynthesized answer');
     });
 
     it('shows search complete when no totalResults', () => {
@@ -176,7 +176,7 @@ describe('WebSearch tool', () => {
         content: [{ type: 'text', text: 'answer' }],
         details: {},
       };
-      expect(renderToolResult(ws, result)).toBe('search complete');
+      expect(renderToolResult(ws, result)).toBe('search complete\nanswer');
     });
 
     it('shows expanded content with summary prefix', () => {


### PR DESCRIPTION
## Summary

Improves the collapsed TUI view for Cursor-style Grok tool shims so long agent sessions stay scannable.

- Add `/grok-cli-tools:{status,minimal,preview}` with persistent config at `~/.pi/grok-cli-tools.json`
- Show bounded previews for Grep/Glob/LS/Shell/WebSearch and Write call content
- Summarize Read results with path/range context
- Show compact StrReplace result diffs with surrounding context
- Hide successful Write collapsed results; keep failure/partial output visible
- Expand test coverage for the new rendering paths

This is a display-only change. Tool semantics, execution, and provider activation are unchanged.

## Motivation

Grok/Composer models call Cursor-style tools frequently. In collapsed view, tool output was either too empty to review or too large to scan. This change adds a small, extension-local display mode so users can choose summary-only or bounded previews without changing pi's global `Ctrl+O` expansion behavior.

## Defaults

| Setting | Default |
| --- | --- |
| Mode | `preview` |
| Grep/Glob/LS/Shell previews | bounded (10/20/20/20) |
| Write call preview | 10 lines |
| Read preview lines | `0` (summary only by default) |
| WebSearch preview | 500 characters |
| Successful Write collapsed result | empty (failures still render) |

## Commands

| Command | Effect |
| --- | --- |
| `/grok-cli-tools:status` | Show mode, limits, config path |
| `/grok-cli-tools:minimal` | Compact summaries only |
| `/grok-cli-tools:preview` | Default bounded previews |

## Design notes / open to maintainer preference

1. **Silent Write success** — successful collapsed Write results intentionally render empty so the transcript is not dominated by write confirmations. A one-line `"N bytes written"` summary is easy to restore if preferred.
2. **Read preview default is 0** — even in `preview` mode, Read stays summary-only unless `readPreviewLines` is raised in config.
3. **Display diffs are compact** — StrReplace diffs are a small context-aware display aid, not a general-purpose diff engine.

## Test plan

- [x] `bun run check`
- [x] Unit coverage for Read summaries/previews, rendering helpers, display-config fallbacks, Write call previews, and StrReplace diffs
- [ ] Manual: run `/grok-cli-tools:minimal` and `/grok-cli-tools:preview`, then exercise Write / StrReplace / Grep / Shell / Read collapsed output
- [ ] Manual: expand a tool result with pi's existing expansion keybinding and confirm full output still works

## Commits

1. `feat: add configurable tool preview modes`
2. `refactor: align Write rendering with call preview`
3. `feat: show StrReplace result diffs`
4. `test: expand coverage for tool display rendering`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable tool display modes: minimal and preview.
  * Added commands to switch modes and view current settings.
  * Tool results now show concise previews for files, searches, shell output, and web searches.
  * File replacement results include readable diffs and improved summaries.

* **Documentation**
  * Added setup instructions, commands, and configuration details to the README.

* **Tests**
  * Added coverage for display settings, previews, diffs, and updated rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->