### PR TITLE
fix: request conversations scopes and align Grok CLI client version

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -7,7 +7,7 @@ Most users do not need these overrides. Only point base URL overrides at endpoin
 | `PI_GROK_CLI_BASE_URL` | `https://cli-chat-proxy.grok.com/v1` | Override the API base URL. |
 | `GROK_CLI_BASE_URL` | — | Fallback when `PI_GROK_CLI_BASE_URL` is unset. |
 | `PI_GROK_CLI_OAUTH_CLIENT_ID` | bundled client ID | Override the OAuth client ID. |
-| `PI_GROK_CLI_OAUTH_SCOPE` | `openid profile email offline_access grok-cli:access api:access` | Override OAuth scopes. |
+| `PI_GROK_CLI_OAUTH_SCOPE` | `openid profile email offline_access grok-cli:access api:access conversations:read conversations:write` | Override OAuth scopes. Must include `conversations:read` and `conversations:write` for cli-chat-proxy access. |
 | `PI_GROK_CLI_CALLBACK_HOST` | `127.0.0.1` | Browser callback host. |
 | `PI_GROK_CLI_CALLBACK_PORT` | `56122` | Preferred callback port; falls back to an ephemeral port. |
 | `PI_GROK_CLI_TOKEN_TIMEOUT_MS` | `30000` | Timeout for OAuth token requests. |

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ See [Advanced configuration](./CONFIGURATION.md) for OAuth, callback, endpoint, 
 | --- | --- |
 | grok-cli is missing from `/model` | Confirm the package appears in `pi list`, run `/login`, choose **Grok CLI**, then restart pi or run `/reload`. |
 | Browser login cannot bind or complete | Paste the complete callback URL into pi when prompted. If xAI displays a one-time code instead, paste it into the same prompt. Otherwise, use device-code login or adjust `PI_GROK_CLI_CALLBACK_HOST` and `PI_GROK_CLI_CALLBACK_PORT`. Never post the callback URL or authorization code publicly. |
-| Authentication returns HTTP 401 or 403 | Run `/login` again and confirm the account can access the selected model. Replace an expired `GROK_CLI_OAUTH_TOKEN` if using the bypass. |
+| Authentication returns HTTP 401 or 403 | Run `/login` again and prefer **Use existing Grok Build login** when the official Grok CLI works. Fresh browser login must request conversation scopes; accounts without SuperGrok/Grok CLI access still get `Access denied`. Replace an expired `GROK_CLI_OAUTH_TOKEN` if using the bypass. The `OpenAI API error` prefix is only Pi's OpenAI-compatible transport wrapper, not a request to OpenAI. |
 | A listed model is unavailable | Availability can differ by account or region, and the catalog is bundled rather than discovered live. Try another model or update the extension. |
 | Images are not being described | Run `/grok-cli-vision:status`, confirm routing is on, and verify Grok authentication. Native image-capable models bypass routing by design. |
 

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -3,10 +3,62 @@ export const XAI_OAUTH_CLIENT_ID =
   process.env.PI_GROK_CLI_OAUTH_CLIENT_ID || 'b1a00492-073a-47ea-816f-4c329264a828';
 export const XAI_TOKEN_ENDPOINT = `${XAI_ISSUER}/oauth2/token`;
 
+// Official Grok CLI requests conversations scopes for cli-chat-proxy access.
+// Keep openid/profile/email/offline_access for Pi's OAuth storage + refresh.
+export const XAI_OAUTH_SCOPE =
+  process.env.PI_GROK_CLI_OAUTH_SCOPE ||
+  'openid profile email offline_access grok-cli:access api:access conversations:read conversations:write';
+
+export const REQUIRED_GROK_CLI_SCOPES = [
+  'grok-cli:access',
+  'conversations:read',
+  'conversations:write',
+] as const;
+
 export function getBaseUrl() {
   return (
     process.env.PI_GROK_CLI_BASE_URL ||
     process.env.GROK_CLI_BASE_URL ||
     'https://cli-chat-proxy.grok.com/v1'
   ).replace(/\/+$/, '');
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
+  const parts = token.split('.');
+  if (parts.length < 2) return undefined;
+  try {
+    const normalized = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4);
+    const json = globalThis.atob(padded);
+    const payload = JSON.parse(json) as unknown;
+    return payload && typeof payload === 'object' && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function tokenScopes(accessToken: string): string[] {
+  const scope = decodeJwtPayload(accessToken)?.scope;
+  return typeof scope === 'string' ? scope.split(/\s+/).filter(Boolean) : [];
+}
+
+export function missingGrokCliScopes(accessToken: string): string[] {
+  const granted = new Set(tokenScopes(accessToken));
+  return REQUIRED_GROK_CLI_SCOPES.filter((scope) => !granted.has(scope));
+}
+
+export function formatGrokCliAccessDeniedHint(accessToken?: string): string {
+  const missing = accessToken ? missingGrokCliScopes(accessToken) : [];
+  if (missing.length > 0) {
+    return (
+      `Grok CLI token is missing required scopes (${missing.join(', ')}). ` +
+      'Run /login grok-cli again (prefer "Use existing Grok Build login" if available) so the token includes conversations:read/write.'
+    );
+  }
+  return (
+    'Grok CLI returned Access denied. Confirm this xAI account has SuperGrok/Grok CLI access, ' +
+    'or run /login grok-cli and choose "Use existing Grok Build login" if the official Grok CLI works on this machine.'
+  );
 }

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -11,7 +11,7 @@
 
 import { createServer } from 'node:http';
 import { XaiErrorCode, XaiOAuthError } from '../shared/errors.js';
-import { getBaseUrl, XAI_ISSUER, XAI_OAUTH_CLIENT_ID } from './config.js';
+import { getBaseUrl, XAI_ISSUER, XAI_OAUTH_CLIENT_ID, XAI_OAUTH_SCOPE } from './config.js';
 import { readGrokCredentials } from './grokCredentials.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -19,9 +19,7 @@ import { readGrokCredentials } from './grokCredentials.js';
 const ISSUER = XAI_ISSUER;
 const DISCOVERY_URL = `${ISSUER}/.well-known/openid-configuration`;
 const CLIENT_ID = XAI_OAUTH_CLIENT_ID;
-const SCOPE =
-  process.env.PI_GROK_CLI_OAUTH_SCOPE ||
-  'openid profile email offline_access grok-cli:access api:access';
+const SCOPE = XAI_OAUTH_SCOPE;
 const CALLBACK_HOST = process.env.PI_GROK_CLI_CALLBACK_HOST || '127.0.0.1';
 const CALLBACK_PORT = Number.parseInt(process.env.PI_GROK_CLI_CALLBACK_PORT || '56122', 10);
 const CALLBACK_PATH = '/callback';

--- a/src/provider/register.ts
+++ b/src/provider/register.ts
@@ -6,6 +6,7 @@ import type {
   OAuthProviderInterface,
 } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { formatGrokCliAccessDeniedHint, missingGrokCliScopes } from '../auth/config.js';
 import * as oauth from '../auth/oauth.js';
 import { getBaseUrl, type XaiOAuthCredentials } from '../auth/oauth.js';
 import { migrateLegacyConfig } from '../config.js';
@@ -101,6 +102,17 @@ export default function registerGrokCli(pi: ExtensionAPI) {
         '[pi-grok-cli] Using GROK_CLI_OAUTH_TOKEN bypass — no auto-refresh, no model discovery',
         'warning',
       );
+    }
+
+    try {
+      const apiKey =
+        process.env.GROK_CLI_OAUTH_TOKEN ??
+        (await ctx.modelRegistry.getApiKeyForProvider?.('grok-cli'));
+      if (apiKey && missingGrokCliScopes(apiKey).length > 0) {
+        ctx.ui.notify(`[pi-grok-cli] ${formatGrokCliAccessDeniedHint(apiKey)}`, 'warning');
+      }
+    } catch {
+      // Auth inspection is best-effort; never block session start.
     }
 
     if (!webSearchRegistered) return;

--- a/src/provider/stream.ts
+++ b/src/provider/stream.ts
@@ -1,6 +1,6 @@
 // Grok CLI client version. Keep it in sync with the version the official Grok
 // CLI client emits (observed in captured cli-chat-proxy.grok.com traffic).
-export const GROK_CLI_VERSION = '0.2.91';
+export const GROK_CLI_VERSION = '0.2.101';
 
 // The version gate reads the client version out of User-Agent. The accepted
 // format is the product/version pair the official clients emit — both the pager

--- a/src/provider/usage.ts
+++ b/src/provider/usage.ts
@@ -1,5 +1,6 @@
 import type { Api, Model } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { formatGrokCliAccessDeniedHint } from '../auth/config.js';
 import { XaiOAuthError } from '../shared/errors.js';
 import { fetchBillingUsage, formatQuota } from './billing.js';
 
@@ -33,10 +34,11 @@ export function registerUsageCommand(pi: Pick<ExtensionAPI, 'registerCommand'>) 
           ctx.ui.notify('Fetching grok cli usage…', 'info');
           ctx.ui.notify(formatQuota(await fetchBillingUsage(apiKey)).join('\n'), 'info');
         } catch (err) {
-          ctx.ui.notify(
-            `Grok CLI billing refresh failed: ${err instanceof Error ? err.message : String(err)}`,
-            'warning',
-          );
+          const message = err instanceof Error ? err.message : String(err);
+          ctx.ui.notify(`Grok CLI billing refresh failed: ${message}`, 'warning');
+          if (/\b403\b|Access denied/i.test(message)) {
+            ctx.ui.notify(formatGrokCliAccessDeniedHint(apiKey), 'warning');
+          }
           ctx.ui.notify(formatQuota(undefined).join('\n'), 'info');
         }
       } catch (err) {

--- a/tests/auth/config.test.ts
+++ b/tests/auth/config.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatGrokCliAccessDeniedHint,
+  missingGrokCliScopes,
+  tokenScopes,
+  XAI_OAUTH_SCOPE,
+} from '../../src/auth/config.js';
+
+function jwt(payload: Record<string, unknown>) {
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `hdr.${body}.sig`;
+}
+
+describe('Grok CLI OAuth scope defaults', () => {
+  it('requests conversations scopes used by the official Grok CLI', () => {
+    expect(XAI_OAUTH_SCOPE).toContain('grok-cli:access');
+    expect(XAI_OAUTH_SCOPE).toContain('conversations:read');
+    expect(XAI_OAUTH_SCOPE).toContain('conversations:write');
+  });
+
+  it('detects tokens missing cli-chat-proxy conversation scopes', () => {
+    const incomplete = jwt({
+      scope: 'openid profile email offline_access grok-cli:access api:access',
+    });
+    expect(tokenScopes(incomplete)).toEqual([
+      'openid',
+      'profile',
+      'email',
+      'offline_access',
+      'grok-cli:access',
+      'api:access',
+    ]);
+    expect(missingGrokCliScopes(incomplete)).toEqual(['conversations:read', 'conversations:write']);
+    expect(formatGrokCliAccessDeniedHint(incomplete)).toContain('missing required scopes');
+  });
+
+  it('accepts official-style tokens with conversation scopes', () => {
+    const complete = jwt({
+      scope:
+        'openid profile email offline_access grok-cli:access api:access conversations:read conversations:write',
+    });
+    expect(missingGrokCliScopes(complete)).toEqual([]);
+    expect(formatGrokCliAccessDeniedHint(complete)).toContain('SuperGrok/Grok CLI access');
+  });
+});

--- a/tests/provider/stream.test.ts
+++ b/tests/provider/stream.test.ts
@@ -3,12 +3,12 @@ import { grokCliModelHeaders } from '../../src/provider/stream.js';
 
 // User-Agent value the live inference endpoint accepts. Mirror of the
 // open-grok-build opencode plugin; changing it here will break the 426 gate.
-const EXPECTED_USER_AGENT = 'grok-pager/0.2.91 grok-shell/0.2.91 (macos; aarch64)';
+const EXPECTED_USER_AGENT = 'grok-pager/0.2.101 grok-shell/0.2.101 (macos; aarch64)';
 
 function expectStaticHeaders(headers: Record<string, string>): void {
   expect(headers['User-Agent']).toBe(EXPECTED_USER_AGENT);
   expect(headers['x-grok-client-identifier']).toBe('grok-pager');
-  expect(headers['x-grok-client-version']).toBe('0.2.91');
+  expect(headers['x-grok-client-version']).toBe('0.2.101');
   expect(headers['x-xai-token-auth']).toBe('xai-grok-cli');
   expect(headers['x-grok-model-override']).toBe('grok-4');
 }


### PR DESCRIPTION
## Summary

Fresh `/login grok-cli` sessions could get tokens that `cli-chat-proxy.grok.com` rejects with `403 Access denied`, while the official Grok CLI on the same machine worked. Pi then wrapped that failure as `OpenAI API error`, which made it look like the wrong provider.

This change makes browser/device login request the official Grok CLI conversation scopes, bumps the client identification headers to the current official Grok CLI version (`0.2.101`), and warns early when a stored token is still missing those scopes.

## Validation

- `bun run check` (lint, typecheck, knip, jscpd, coverage)
- 415 tests passed
- Local reproduction before the fix:
  - incomplete/non-CLI-capable token → `cli-chat-proxy` 403
  - official Grok CLI token with conversation scopes → 200

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Grok_4.5_%28500K%29-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error guidance for missing conversation permissions and expired credentials.
  * Added clearer troubleshooting instructions for HTTP 401/403 errors.
  * Detects insufficient access scopes during session startup without blocking the session.
  * Improved billing refresh error messages for access-denied failures.

* **Documentation**
  * Updated documented OAuth defaults to include conversation read and write permissions.
  * Expanded authentication troubleshooting guidance.

* **Maintenance**
  * Updated the reported Grok CLI version and client headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->